### PR TITLE
Speed up setup.sh by shallow cloning the Linux kernel submodule

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git submodule update --init
+git submodule update --init --depth 1


### PR DESCRIPTION
Use --depth 1 with git submodule update to avoid downloading the full history of the Linux kernel, which significantly reduces clone time and disk usage.