### PR TITLE
build: only add cross compiler if not on aarch64

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -6,10 +6,10 @@ RUN xbps-install -y \
     base-devel \
     bash \
     ccache \
-    cross-aarch64-linux-gnu \
     git \
     openssl-devel \
     python3 && \
+    if [ "$(uname -m)" != "aarch64" ]; then xbps-install -y cross-aarch64-linux-gnu; fi && \
     xbps-remove -O
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
splitting from https://github.com/commaai/vamOS/pull/6

testing: `./build_kernel.sh` on my x86 machine

```
vamOS on  crossarch [!] took 4s
❯ uname -a
Linux cube 6.17.0-14-generic #14~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Jan 15 15:52:10 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
```