### PR TITLE
ci: add concurrency key to kernel build

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -1,5 +1,9 @@
 name: build kernel
 
+concurrency:
+  group: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.run_id || github.head_ref || github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
prevent canceling master builds