### PR TITLE
build: upgrade system-builder to Ubuntu 24.04 for img2simg fix

### DIFF
--- a/tools/build/Dockerfile.system-builder
+++ b/tools/build/Dockerfile.system-builder
@@ -1,6 +1,6 @@
 # check=error=true
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG UNAME
 ARG UID
@@ -10,11 +10,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    python2 \
     build-essential \
     libssl-dev \
     bc \
-    python-is-python2 \
     openssl \
     ccache \
     libcap2-bin \


### PR DESCRIPTION
## Summary
- Upgrades `Dockerfile.system-builder` from Ubuntu 20.04 to 24.04
- Fixes `img2simg` "Failed to write sparse file" error on the 6GB system image — Ubuntu 20.04 ships v8.1.0 which can't handle large images with many data chunks, while 24.04 ships v34.0.4
- Removes `python2` and `python-is-python2` packages (unavailable on 24.04, unused by system-builder)

## Test plan
- [x] Reproduced failure with Ubuntu 20.04 img2simg on 6GB ext4 image
- [x] Confirmed Ubuntu 24.04 img2simg handles the same workload
- [x] Full `vamos build system` completes successfully with the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)