### PR TITLE
build: only build our device tree to speed up kernel build

### DIFF
--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -81,7 +81,7 @@ build_kernel() {
   make olddefconfig O=out
 
   echo "-- Building kernel with $(nproc) cores --"
-  make -j$(nproc) O=out Image.gz "arch/arm64/boot/dts/$DTB"
+  make -j$(nproc) O=out Image.gz "$DTB"
 
   # Assemble Image.gz-dtb
   mkdir -p "$TMP_DIR"


### PR DESCRIPTION
## Summary
- Only build our specific device tree (`$DTB`) instead of all DTBs during kernel build, speeding up the build

## Test plan
- [x] Build kernel with `./vamos build kernel`
- [x] Verify the resulting `boot.img` contains the correct device tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)