### PR TITLE
kernel: enable overlay filesystem

### DIFF
--- a/kernel/configs/vamos.config
+++ b/kernel/configs/vamos.config
@@ -1,3 +1,6 @@
+# Overlay filesystem
+CONFIG_OVERLAY_FS=y
+
 # UFS
 CONFIG_PHY_QCOM_QMP=y
 CONFIG_PHY_QCOM_QMP_UFS=y


### PR DESCRIPTION
## Summary
- Build `CONFIG_OVERLAY_FS` into the kernel instead of as a module
- Fixes `/home/comma` not being populated on boot — the overlay mount in `fs_setup.sh` was silently failing because the overlay module wasn't available

## Test plan
- [x] Flash kernel and verify `/home/comma` is populated on boot
- [x] Verify `grep overlay /proc/filesystems` shows `overlay`

```
❯ ssh comma@192.168.42.2
                      .~ssos+.
                    +8888888888i,
                   {888888888888o.
                   h8888888888888k
                   t888888888s888k
                    `t88888d/ h88k
                       ```    h88l
                             ,88k`
                            .d8h`
                           +d8h
                        _+d8h`
                      ;y8h+`
                      |-`


Welcome to vamOS v17.2 (a7329a5)
Based on Void Linux (GNU/Linux 6.18.0-g7d0a66e4bb90-dirty aarch64)

Here are some useful commands:
  Enter the tmux session where the comma service runs
  (note: tmux prefix key has been configured to backtick)
    └── tmux a

  Install packages
    └── sudo xbps-install -S <pkg>

  Install Python packages
    └── pip install <pkg>

When modifying vamOS, keep in mind that the system partition isn't
particularly large. /data/ is the largest partition, and unlike the
rest of the partitions, it will persist across vamOS updates.

Want a clean slate? Reflash vamOS with https://flash.comma.ai.

error connecting to /tmp/tmux-1000/default (No such file or directory)
comma@comma-725dfb9b:~$

comma@comma-725dfb9b:~$ grep overlay /proc/filesystems
nodev	overlay
comma@comma-725dfb9b:~$
```