### PR TITLE
kernel/dts: move INA231 from common dtsi to tizi

### DIFF
--- a/kernel/dts/sdm845-comma-common.dtsi
+++ b/kernel/dts/sdm845-comma-common.dtsi
@@ -351,17 +351,6 @@
 	status = "okay";
 };
 
-&i2c10 {
-	status = "okay";
-	clock-frequency = <100000>;
-
-	ina231@40 {
-		compatible = "ti,ina231";
-		reg = <0x40>;
-		shunt-resistor = <30000>;
-	};
-};
-
 &ufs_mem_hc {
 	status = "okay";
 

--- a/kernel/dts/sdm845-comma-tizi.dts
+++ b/kernel/dts/sdm845-comma-tizi.dts
@@ -8,3 +8,14 @@
 	qcom,msm-id = <341 0x20001>, <321 0x20001>, <321 0x20000>, <348 0x20001>;
 	qcom,board-id = <0x21 0>;
 };
+
+&i2c10 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	ina231@40 {
+		compatible = "ti,ina231";
+		reg = <0x40>;
+		shunt-resistor = <30000>;
+	};
+};


### PR DESCRIPTION
## Summary
- Move the i2c10 INA231 node from `sdm845-comma-common.dtsi` to `sdm845-comma-tizi.dts`
- Mici does not have an INA, so it should not be in the common device tree

## Test plan
- [x] Verify tizi builds with the INA231 node in its board-specific DTS
- [x] Verify mici builds without the INA231 node