### PR TITLE
kernel/configs: rename remoteproc section from modem to wifi

### DIFF
--- a/kernel/configs/vamos.config
+++ b/kernel/configs/vamos.config
@@ -22,7 +22,7 @@ CONFIG_USB_SERIAL_OPTION=y
 # Networking
 CONFIG_IPV6=y
 
-# Modem / Remoteproc
+# WiFi / Remoteproc
 CONFIG_QCOM_Q6V5_COMMON=y
 CONFIG_QCOM_Q6V5_MSS=y
 CONFIG_QCOM_SYSMON=y
@@ -33,7 +33,7 @@ CONFIG_QCOM_PDR_HELPERS=y
 CONFIG_RPMSG_CHAR=y
 CONFIG_RESET_QCOM_PDC=y
 
-# PPP (for LTE modem data connection)
+# PPP (for USB LTE modem data connection)
 CONFIG_PPP=y
 CONFIG_PPP_ASYNC=y
 CONFIG_PPP_DEFLATE=y


### PR DESCRIPTION
## Summary
- Rename `# Modem / Remoteproc` → `# WiFi / Remoteproc` since Q6V5 MSS/QRTR/remoteproc bring up the wireless subsystem, not the USB LTE modem
- Clarify PPP section comment to specify it's for the USB LTE modem

## Test plan
- [x] Verify defconfig builds correctly