### PR TITLE
tools/build: use separate tmp dirs for parallel builds

### DIFF
--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -7,7 +7,7 @@ cd "$DIR"
 TOOLS="$DIR/tools/bin"
 KERNEL_DIR="$DIR/kernel/linux"
 PATCHES_DIR="$DIR/kernel/patches"
-TMP_DIR="$DIR/build/tmp"
+TMP_DIR="$DIR/build/tmp-kernel"
 OUT_DIR="$DIR/build"
 BOOT_IMG=./boot.img
 

--- a/tools/build/build_system.sh
+++ b/tools/build/build_system.sh
@@ -10,7 +10,7 @@ cd "$DIR"
 
 DOWNLOADS_DIR="$DIR/build/downloads"
 VOID_ROOTFS_FILE="$DOWNLOADS_DIR/void-aarch64-ROOTFS-20250202.tar.xz"
-BUILD_DIR="$DIR/build/tmp"
+BUILD_DIR="$DIR/build/tmp-system"
 OUTPUT_DIR="$DIR/build"
 
 ROOTFS_DIR="$BUILD_DIR/void-rootfs"


### PR DESCRIPTION
## Summary
- Use tmp-kernel and tmp-system instead of shared tmp dir so kernel and system builds can run concurrently without conflicts

## Test plan
- [ ] Run kernel and system builds in parallel
- [ ] Confirm build outputs are still in build/

Generated with [Claude Code](https://claude.com/claude-code)