### PR TITLE
fix: rename device model to match current device tree

### DIFF
--- a/kernel/dts/sdm845-comma-mici.dts
+++ b/kernel/dts/sdm845-comma-mici.dts
@@ -3,7 +3,7 @@
 #include "sdm845-comma-common.dtsi"
 
 / {
-	model = "comma.ai mici";
+	model = "comma mici";
 	compatible = "comma,mici", "qcom,sdm845";
 	qcom,msm-id = <341 0x20001>, <321 0x20001>, <321 0x20000>, <348 0x20001>;
 	qcom,board-id = <0x22 0>;

--- a/kernel/dts/sdm845-comma-tizi.dts
+++ b/kernel/dts/sdm845-comma-tizi.dts
@@ -3,7 +3,7 @@
 #include "sdm845-comma-common.dtsi"
 
 / {
-	model = "comma.ai tizi";
+	model = "comma tizi";
 	compatible = "comma,tizi", "qcom,sdm845";
 	qcom,msm-id = <341 0x20001>, <321 0x20001>, <321 0x20000>, <348 0x20001>;
 	qcom,board-id = <0x21 0>;


### PR DESCRIPTION
likely other places, too: https://github.com/commaai/openpilot/blob/54db569c2cd30deb75f1fbfac5bc80afbced247c/system/hardware/tici/hardware.py#L77-L79