### PR TITLE
kernel: add focaltech ft3168 touchscreen

### DIFF
--- a/kernel/configs/vamos.config
+++ b/kernel/configs/vamos.config
@@ -62,6 +62,9 @@ CONFIG_I2C_QCOM_GENI=y
 # Power monitoring (INA231)
 CONFIG_SENSORS_INA2XX=y
 
+# Touchscreen
+CONFIG_TOUCHSCREEN_EDT_FT5X06=y
+
 # GPIO
 # TODO: migrate gpio.sh, lte.sh, and power_drop_monitor.py to chardev (libgpiod)
 # and remove GPIO_SYSFS (deprecated)

--- a/kernel/dts/sdm845-comma-common.dtsi
+++ b/kernel/dts/sdm845-comma-common.dtsi
@@ -357,6 +357,10 @@
 	vdds-supply = <&vdda_mipi_dsi0_pll>;
 };
 
+&qupv3_id_0 {
+	status = "okay";
+};
+
 &qupv3_id_1 {
 	status = "okay";
 };

--- a/kernel/dts/sdm845-comma-mici.dts
+++ b/kernel/dts/sdm845-comma-mici.dts
@@ -20,6 +20,26 @@
 	};
 };
 
+&i2c5 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	touchscreen@38 {
+		compatible = "focaltech,ft3168";
+		reg = <0x38>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <125 IRQ_TYPE_EDGE_FALLING>;
+		reset-gpios = <&tlmm 104 GPIO_ACTIVE_LOW>;
+
+		iovcc-supply = <&vreg_s4a_1p8>;
+		vcc-supply = <&lcd3v3>;
+
+		touchscreen-size-x = <240>;
+		touchscreen-size-y = <536>;
+	};
+};
+
 &mdss_dsi0 {
 	panel@0 {
 		compatible = "dwo,do0200fat07";

--- a/kernel/patches/0007-input-edt-ft5x06-add-support-for-FocalTech-FT3168.patch
+++ b/kernel/patches/0007-input-edt-ft5x06-add-support-for-FocalTech-FT3168.patch
@@ -1,0 +1,43 @@
+From 98ef45adca93ac64657409bec38cb0117304862c Mon Sep 17 00:00:00 2001
+From: Robin Reckmann <robin.reckmann@gmail.com>
+Date: Thu, 26 Mar 2026 21:31:22 +0900
+Subject: input: edt-ft5x06 - add support for FocalTech FT3168
+
+---
+ drivers/input/touchscreen/edt-ft5x06.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/input/touchscreen/edt-ft5x06.c b/drivers/input/touchscreen/edt-ft5x06.c
+index bf498bd4d..261401936 100644
+--- a/drivers/input/touchscreen/edt-ft5x06.c
++++ b/drivers/input/touchscreen/edt-ft5x06.c
+@@ -1475,6 +1475,10 @@ static const struct edt_i2c_chip_data edt_ft5x06_data = {
+ 	.max_support_points = 5,
+ };
+ 
++static const struct edt_i2c_chip_data edt_ft3168_data = {
++	.max_support_points = 2,
++};
++
+ static const struct edt_i2c_chip_data edt_ft5452_data = {
+ 	.max_support_points = 5,
+ };
+@@ -1505,6 +1509,7 @@ static const struct i2c_device_id edt_ft5x06_ts_id[] = {
+ 	{ .name = "ev-ft5726", .driver_data = (long)&edt_ft5506_data },
+ 	{ .name = "ft5452", .driver_data = (long)&edt_ft5452_data },
+ 	/* Note no edt- prefix for compatibility with the ft6236.c driver */
++	{ .name = "ft3168", .driver_data = (long)&edt_ft3168_data },
+ 	{ .name = "ft6236", .driver_data = (long)&edt_ft6236_data },
+ 	{ .name = "ft8201", .driver_data = (long)&edt_ft8201_data },
+ 	{ .name = "ft8716", .driver_data = (long)&edt_ft8716_data },
+@@ -1519,6 +1524,7 @@ static const struct of_device_id edt_ft5x06_of_match[] = {
+ 	{ .compatible = "edt,edt-ft5406", .data = &edt_ft5x06_data },
+ 	{ .compatible = "edt,edt-ft5506", .data = &edt_ft5506_data },
+ 	{ .compatible = "evervision,ev-ft5726", .data = &edt_ft5506_data },
++	{ .compatible = "focaltech,ft3168", .data = &edt_ft3168_data },
+ 	{ .compatible = "focaltech,ft5426", .data = &edt_ft5506_data },
+ 	{ .compatible = "focaltech,ft5452", .data = &edt_ft5452_data },
+ 	/* Note focaltech vendor prefix for compatibility with ft6236.c */
+-- 
+2.53.0
+


### PR DESCRIPTION
- add focaltech ft3168 touchscreen driver
- enable i2c5 and touchscreen driver for mici

Test
- [ ] Run evtest and confirm touch is registered properly