### PR TITLE
system: deploy QCA bluetooth firmware to rootfs

### DIFF
--- a/tools/build/Dockerfile
+++ b/tools/build/Dockerfile
@@ -66,9 +66,10 @@ RUN cd /tmp/vamos/uv && \
     MAKEFLAGS="-j$(nproc)" UV_CONCURRENT_BUILDS=4 UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=$XDG_DATA_HOME/venv \
     uv sync --frozen --inexact
 
-# Install firmware from upstream linux-firmware (ath10k WiFi + modem)
+# Install firmware from upstream linux-firmware (ath10k WiFi + modem + Bluetooth)
 COPY ./kernel/firmware/ath10k/WCN3990/hw1.0 /lib/firmware/ath10k/WCN3990/hw1.0
 COPY ./kernel/firmware/qcom/sdm845 /lib/firmware/qcom/sdm845
+COPY ./kernel/firmware/qca /lib/firmware/qca
 RUN ln -sf /lib/firmware/ath10k/WCN3990/hw1.0/wlanmdsp.mbn /lib/firmware/qcom/sdm845/wlanmdsp.mbn
 
 # Root filesystem overlay — all userspace files at their final paths


### PR DESCRIPTION
## Summary
- The bluetooth bringup PR (#77) added firmware files to `kernel/firmware/qca/` but missed copying them into the system image via the Dockerfile
- Without these files, the WCN3990 BT controller fails to load firmware on boot (`Direct firmware load for qca/crbtfw21.tlv failed with error -2`)
- Adds `COPY ./kernel/firmware/qca /lib/firmware/qca` alongside the existing WiFi and modem firmware COPY lines

## Test plan
- [x] Manually deployed firmware to mici, confirmed `QCA setup on UART is completed` in dmesg after restart
- [x] Build system image and verify `/lib/firmware/qca/` contains `crbtfw*.tlv` and `crnv*.bin`