### PR TITLE
Adding qemu vm scripts to boot the kernel locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ a new operating system for comma 3X and comma four
 ./vamos setup              # init submodules and udev rules
 ./vamos build kernel       # build boot.img
 ./vamos build system       # build system.img
+./vamos vm prepare         # init qemu package
+./vamos vm bash            # run bash in kernel and system
+./vamos vm run             # run full system and kernel
+./vamos vm kill            # kill qemu as system has no promt
 ./vamos flash kernel       # flash boot.img via EDL
 ./vamos flash system       # flash system.img via EDL
 ./vamos flash all          # flash both

--- a/tools/vamos
+++ b/tools/vamos
@@ -40,6 +40,14 @@ case "${1:-}" in
       all)      "$DIR/tools/flash/gpt.sh" && "$DIR/tools/flash/firmware.sh" && "$DIR/tools/flash/kernel.sh" && "$DIR/tools/flash/system.sh" ;;
       *)        echo "Usage: vamos flash <kernel|system|firmware|gpt|all>"; exit 1 ;;
     esac ;;
+  vm)
+    case "${2:-}" in
+      prepare)  exec "$DIR/tools/vm/prepare.sh" ;;
+      bash)     exec "$DIR/tools/vm/bash.sh" ;;
+      run)      exec "$DIR/tools/vm/run.sh" ;;
+      kill)     exec "$DIR/tools/vm/kill.sh" ;;
+      *)        echo "Usage: vamos vm <prepare|bash|run|kill>"; exit 1 ;;
+    esac ;;
   profile)
     shift
     exec "$DIR/tools/profile/rootfs.sh" "$@" ;;
@@ -49,6 +57,10 @@ case "${1:-}" in
     echo "  setup              Initialize submodules and udev rules"
     echo "  build kernel       Build the kernel (output/boot.img)"
     echo "  build system       Build the system image (output/system.img)"
+    echo "  vm prepare         Prepare the VM environment using QEMU"
+    echo "  vm bash            Run a bash shell in the VM"
+    echo "  vm run             Run the VM with the built kernel and system"
+    echo "  vm kill            Kill the VM"
     echo "  flash kernel       Flash boot.img to device via EDL (--legacy for legacy kernel)"
     echo "  flash system       Flash system.img to device via EDL"
     echo "  flash firmware     Flash firmware partitions to device via EDL"

--- a/tools/vm/bash.sh
+++ b/tools/vm/bash.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
+cd "$DIR"
+
+BUILD_DIR="$DIR/build"
+tools/vm/run.sh "init=/bin/bash"

--- a/tools/vm/kill.sh
+++ b/tools/vm/kill.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+sudo killall -9 qemu-system-aarch64 || true

--- a/tools/vm/prepare.sh
+++ b/tools/vm/prepare.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
+cd "$DIR"
+
+BUILD_DIR="$DIR/build"
+
+# Arch Linux
+if [ -f /usr/bin/pacman ]; then
+  sudo pacman -S --needed \
+    docker \
+    jq \
+    docker-buildx \
+    bc \
+    qemu-full \
+    android-tools
+ 
+  if ! systemctl is-active --quiet docker.service; then
+    sudo systemctl start docker.service
+  fi
+
+fi
+
+# Ubuntu/Debian
+if [ -f /usr/bin/apt ]; then
+  sudo apt-get install \
+    jq \
+    git-lfs \
+    docker.io \
+    docker-buildx \
+    qemu-system \
+    android-sdk-libsparse-utils \
+    bc \
+    -y
+
+  if ! systemctl is-active --quiet docker.service; then
+    sudo systemctl start docker.service
+  fi
+fi
+
+if ! groups "$USER" | grep -q "\bdocker\b"; then
+  echo "Adding $USER to docker group..."
+  sudo groupadd docker || true
+  sudo usermod -aG docker "$USER"
+  echo "Please log out and log back in for docker group changes to take effect."
+fi
+
+if [ ${BUILD_DIR}/system.img -nt ${BUILD_DIR}/system_raw.img ]; then
+  echo "Converting system.img to raw format..."
+  simg2img ${BUILD_DIR}/system.img ${BUILD_DIR}/system_raw.img
+else
+  echo "system_raw.img is up to date."
+fi

--- a/tools/vm/run.sh
+++ b/tools/vm/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
+cd "$DIR"
+
+if [ ! -f "$DIR/build/system_raw.img" ]; then
+  echo "system_raw.img not found, running prepare step..."
+  "$DIR/tools/vm/prepare.sh"
+fi
+
+BUILD_DIR="$DIR/build"
+EXTRA_CMDLINE="${1:-}"
+set -x
+qemu-system-aarch64 \
+  -machine virt \
+  -cpu cortex-a57 \
+  -smp 8 \
+  -m 4G \
+  -kernel ./kernel/linux/out/arch/arm64/boot/Image \
+  -drive file=${BUILD_DIR}/system_raw.img,if=virtio,format=raw \
+  -no-reboot \
+  -append "root=/dev/vda console=ttyAMA0 loglevel=7 earlycon=pl011,0x9000000 panic=-1 ${EXTRA_CMDLINE}" \
+  -nographic


### PR DESCRIPTION
This lets us boot the kernel and brower the files system

It has been tested on Ubuntu 24.04 (Running on Windows 11 with WSL), and Arch Linux

```
[jeff@Jeff-Pocket4 vamOS]$ ./vamos vm bash
+ qemu-system-aarch64 -machine virt -cpu cortex-a57 -smp 8 -m 4G -kernel ./kernel/linux/out/arch/arm64/boot/Image -drive file=/commaai/vamOS/build/system_raw.img,if=virtio,format=raw -no-reboot -append 'root=/dev/vda console=ttyAMA0 loglevel=7 earlycon=pl011,0x9000000 panic=-1 init=/bin/bash' -nographic
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd070]
[    0.000000] Linux version 6.18.0-vamos-66a1c3a (vamos@vamos) (aarch64-none-elf-gcc (Alpine Linux) 15.2.0, GNU ld (GNU Binutils) 2.44) #2 SMP PREEMPT Sat Mar 28 23:23:57 UTC 2026
[    0.000000] KASLR enabled
...
[    0.712314] Run /bin/bash as init process
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
bash-5.3# 
bash-5.3# uname -a
Linux (none) 6.18.0-vamos-66a1c3a #2 SMP PREEMPT Sat Mar 28 23:23:57 UTC 2026 aarch64 GNU/Linux
bash-5.3# exit
exit
[   33.208639] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000000
...
[   33.212570] Memory Limit: none
[jeff@Jeff-Pocket4 vamOS]$ 
```

We can add new init script to run simple tests later. 