### PR TITLE
build: Use docker volumes instead of bind-mounts to speed up kernel build on macOS

### DIFF
--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -39,7 +39,7 @@ prepare_ccache_volume() {
 
 kernel_workspace_ready() {
   docker run --rm --entrypoint sh -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder \
-    -lc "test -f /linux/Makefile && test \"\$(cat /linux/.vamos-kernel-rev 2>/dev/null)\" = \"$KERNEL_REV\"" \
+    -lc "test -f /linux/Makefile && test \"\$(git -c safe.directory=/linux -C /linux rev-parse HEAD 2>/dev/null)\" = \"$KERNEL_REV\"" \
     >/dev/null
 }
 

--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -26,13 +26,12 @@ CCACHE_VOLUME="vamos-kernel-ccache"
 CONTAINER_ID=""
 
 prepare_kernel_volume() {
-  local prep_container_id
-
   docker volume create "$KERNEL_LINUX_VOLUME" >/dev/null
-  prep_container_id=$(docker run -d --entrypoint tail -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder -f /dev/null)
-
-  docker exec "$prep_container_id" sh -lc "mkdir -p /linux && chown $(id -u):$(id -g) /linux && chmod 0775 /linux"
-  docker container rm -f "$prep_container_id" >/dev/null
+  docker run --rm \
+    --entrypoint sh \
+    -v "$KERNEL_LINUX_VOLUME:/linux" \
+    vamos-builder \
+    -lc "mkdir -p /linux && chown $(id -u):$(id -g) /linux && chmod 0775 /linux"
 }
 
 seed_kernel_workspace() {
@@ -42,6 +41,7 @@ seed_kernel_workspace() {
   sync_container_id=$(docker run -d --entrypoint tail -v "$DIR:/repo:ro" -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder -f /dev/null)
 
   docker exec "$sync_container_id" sh -lc "rm -rf /linux/* /linux/.[!.]* /linux/..?*"
+  # Force pack-based transfer from the macOS bind mount into the Docker volume.
   docker exec -u "$(id -u):$(id -g)" "$sync_container_id" sh -lc "cd /linux && git clone --no-local /repo/kernel/linux . >/dev/null 2>&1 && git checkout --force '$KERNEL_REV' >/dev/null 2>&1"
   docker container rm -f "$sync_container_id" >/dev/null
 }
@@ -58,6 +58,7 @@ prepare_ccache_volume() {
 }
 
 kernel_workspace_ready() {
+  docker volume inspect "$KERNEL_LINUX_VOLUME" >/dev/null 2>&1 || return 1
   docker run --rm --entrypoint sh -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder \
     -lc "test \"\$(git -c safe.directory=/linux -C /linux rev-parse HEAD 2>/dev/null)\" = \"$KERNEL_REV\"" \
     >/dev/null

--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -20,6 +20,29 @@ DTS_FILES=(
   "$DIR/kernel/dts/sdm845-comma-tizi.dts"
 )
 
+HOST_OS="$(uname)"
+KERNEL_LINUX_VOLUME="vamos-kernel-linux"
+CCACHE_VOLUME="vamos-kernel-ccache"
+KERNEL_REV="$(git -C "$KERNEL_DIR" rev-parse HEAD)"
+CONTAINER_ID=""
+
+prepare_ccache_volume() {
+  if ! docker volume inspect "$CCACHE_VOLUME" >/dev/null 2>&1; then
+    docker volume create "$CCACHE_VOLUME" >/dev/null
+    docker run --rm \
+      --entrypoint sh \
+      -v "$CCACHE_VOLUME:/ccache" \
+      vamos-builder \
+      -lc "mkdir -p /ccache && chown $(id -u):$(id -g) /ccache && chmod 0775 /ccache"
+  fi
+}
+
+kernel_workspace_ready() {
+  docker run --rm --entrypoint sh -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder \
+    -lc "test -f /linux/Makefile && test \"\$(cat /linux/.vamos-kernel-rev 2>/dev/null)\" = \"$KERNEL_REV\"" \
+    >/dev/null
+}
+
 # Check submodule initted, need to run setup
 if [ ! -f "$KERNEL_DIR/Makefile" ]; then
   "$DIR/vamos" setup
@@ -34,7 +57,22 @@ docker build -f tools/build/Dockerfile.builder -t vamos-builder "$DIR" \
   --build-arg GID="$(id -g)"
 
 echo "Starting vamos-builder container"
-CONTAINER_ID=$(docker run -d -u "$(id -u):$(id -g)" -v "$DIR":"$DIR" -w "$DIR" vamos-builder)
+if [ "$HOST_OS" = "Darwin" ]; then
+  if ! kernel_workspace_ready; then
+    echo "Kernel workspace volume is missing or uninitialized; running ./vamos setup"
+    "$DIR/vamos" setup
+  fi
+  prepare_ccache_volume
+  CONTAINER_ID=$(docker run -d \
+    -u "$(id -u):$(id -g)" \
+    -v "$DIR":"$DIR" \
+    -v "$KERNEL_LINUX_VOLUME:$KERNEL_DIR" \
+    -v "$CCACHE_VOLUME:/ccache" \
+    -w "$DIR" \
+    vamos-builder)
+else
+  CONTAINER_ID=$(docker run -d -u "$(id -u):$(id -g)" -v "$DIR":"$DIR" -w "$DIR" vamos-builder)
+fi
 
 trap cleanup EXIT
 
@@ -70,14 +108,18 @@ build_kernel() {
   fi
 
   # ccache
-  export CCACHE_DIR="$DIR/.ccache"
+  if [ "$HOST_OS" = "Darwin" ]; then
+    export CCACHE_DIR="/ccache"
+  else
+    export CCACHE_DIR="$DIR/.ccache"
+  fi
   export PATH="/usr/lib/ccache/bin:$PATH"
 
   # Reproducible builds
   export KBUILD_BUILD_USER="vamos"
   export KBUILD_BUILD_HOST="vamos"
   export KCFLAGS="-w"
-  
+
   GIT_REV="$(git -C $DIR rev-parse --short HEAD)"
   export LOCALVERSION="-vamos-$GIT_REV"
 
@@ -155,7 +197,15 @@ clean_kernel_tree() {
 cleanup() {
   echo "Cleaning up container and kernel tree..."
 
-  clean_kernel_tree
+  if [ "$HOST_OS" = "Darwin" ]; then
+    docker exec -i -u "$(id -u):$(id -g)" "$CONTAINER_ID" bash >/dev/null 2>&1 <<EOF || true
+$(declare -f clean_kernel_tree)
+KERNEL_DIR='$KERNEL_DIR'
+clean_kernel_tree
+EOF
+  else
+    clean_kernel_tree
+  fi
 
   docker container rm -f "${CONTAINER_ID:-}" >/dev/null 2>&1 || true
   rm -rf "$TMP_DIR"
@@ -176,6 +226,7 @@ install_dts() {
 docker exec -i -u "$(id -u):$(id -g)" "$CONTAINER_ID" bash <<EOF
 set -e
 
+HOST_OS='$HOST_OS'
 BASE_DEFCONFIG='$BASE_DEFCONFIG'
 CONFIG_FRAGMENT='$CONFIG_FRAGMENT'
 COMMON_DTSI='$COMMON_DTSI'

--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -25,6 +25,27 @@ KERNEL_LINUX_VOLUME="vamos-kernel-linux"
 CCACHE_VOLUME="vamos-kernel-ccache"
 CONTAINER_ID=""
 
+prepare_kernel_volume() {
+  local prep_container_id
+
+  docker volume create "$KERNEL_LINUX_VOLUME" >/dev/null
+  prep_container_id=$(docker run -d --entrypoint tail -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder -f /dev/null)
+
+  docker exec "$prep_container_id" sh -lc "mkdir -p /linux && chown $(id -u):$(id -g) /linux && chmod 0775 /linux"
+  docker container rm -f "$prep_container_id" >/dev/null
+}
+
+seed_kernel_workspace() {
+  local sync_container_id
+
+  echo "Syncing kernel/linux into Docker volume"
+  sync_container_id=$(docker run -d --entrypoint tail -v "$DIR:/repo:ro" -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder -f /dev/null)
+
+  docker exec "$sync_container_id" sh -lc "rm -rf /linux/* /linux/.[!.]* /linux/..?*"
+  docker exec -u "$(id -u):$(id -g)" "$sync_container_id" sh -lc "cd /linux && git clone --no-local /repo/kernel/linux . >/dev/null 2>&1 && git checkout --force '$KERNEL_REV' >/dev/null 2>&1"
+  docker container rm -f "$sync_container_id" >/dev/null
+}
+
 prepare_ccache_volume() {
   if ! docker volume inspect "$CCACHE_VOLUME" >/dev/null 2>&1; then
     docker volume create "$CCACHE_VOLUME" >/dev/null
@@ -38,7 +59,7 @@ prepare_ccache_volume() {
 
 kernel_workspace_ready() {
   docker run --rm --entrypoint sh -v "$KERNEL_LINUX_VOLUME:/linux" vamos-builder \
-    -lc "test -f /linux/Makefile && test \"\$(git -c safe.directory=/linux -C /linux rev-parse HEAD 2>/dev/null)\" = \"$KERNEL_REV\"" \
+    -lc "test \"\$(git -c safe.directory=/linux -C /linux rev-parse HEAD 2>/dev/null)\" = \"$KERNEL_REV\"" \
     >/dev/null
 }
 
@@ -60,8 +81,9 @@ docker build -f tools/build/Dockerfile.builder -t vamos-builder "$DIR" \
 echo "Starting vamos-builder container"
 if [ "$HOST_OS" = "Darwin" ]; then
   if ! kernel_workspace_ready; then
-    echo "Kernel workspace volume is missing or uninitialized; running ./vamos setup"
-    "$DIR/vamos" setup
+    echo "Kernel workspace volume is missing, uninitialized, or out of date; reseeding"
+    prepare_kernel_volume
+    seed_kernel_workspace
   fi
   prepare_ccache_volume
   CONTAINER_ID=$(docker run -d \

--- a/tools/build/build_kernel.sh
+++ b/tools/build/build_kernel.sh
@@ -23,7 +23,6 @@ DTS_FILES=(
 HOST_OS="$(uname)"
 KERNEL_LINUX_VOLUME="vamos-kernel-linux"
 CCACHE_VOLUME="vamos-kernel-ccache"
-KERNEL_REV="$(git -C "$KERNEL_DIR" rev-parse HEAD)"
 CONTAINER_ID=""
 
 prepare_ccache_volume() {
@@ -47,6 +46,8 @@ kernel_workspace_ready() {
 if [ ! -f "$KERNEL_DIR/Makefile" ]; then
   "$DIR/vamos" setup
 fi
+
+KERNEL_REV="$(git -C "$KERNEL_DIR" rev-parse HEAD)"
 
 # Build docker container
 echo "Building vamos-builder docker image"

--- a/tools/vamos
+++ b/tools/vamos
@@ -8,8 +8,33 @@ while [ -L "$SOURCE" ]; do
 done
 DIR="$(cd "$(dirname "$SOURCE")/.." >/dev/null && pwd)"
 
+seed_kernel_workspace() {
+  local linux_volume sync_container_id kernel_rev
+
+  linux_volume="vamos-kernel-linux"
+  kernel_rev="$(git -C "$DIR/kernel/linux" rev-parse HEAD)"
+
+  echo "Syncing kernel/linux into Docker volume"
+  sync_container_id=$(docker run -d --entrypoint tail -v "$linux_volume:/linux" vamos-builder -f /dev/null)
+
+  docker exec "$sync_container_id" sh -lc "rm -rf /linux/* /linux/.[!.]* /linux/..?*"
+
+  tar -C "$DIR/kernel/linux" -cf - . | docker exec -i "$sync_container_id" tar -xf - -C /linux
+  docker exec "$sync_container_id" sh -lc "printf '%s\n' '$kernel_rev' > /linux/.vamos-kernel-rev"
+  docker container rm -f "$sync_container_id" >/dev/null
+}
+
 setup() {
   git -C "$DIR" submodule update --init --depth 1
+  if [ "$(uname)" = "Darwin" ]; then
+    export DOCKER_BUILDKIT=1
+    docker build -f tools/build/Dockerfile.builder -t vamos-builder "$DIR" \
+      --build-arg UNAME="$(id -nu)" \
+      --build-arg UID="$(id -u)" \
+      --build-arg GID="$(id -g)"
+    docker volume create "vamos-kernel-linux" >/dev/null
+    seed_kernel_workspace
+  fi
   if [ "$(uname)" = "Linux" ]; then
     UDEV_RULES="/etc/udev/rules.d/99-qualcomm-edl.rules"
     if [ ! -f "$UDEV_RULES" ]; then

--- a/tools/vamos
+++ b/tools/vamos
@@ -33,7 +33,9 @@ seed_kernel_workspace() {
 }
 
 setup() {
-  git -C "$DIR" submodule update --init --depth 1
+  if ! git -C "$DIR/kernel/linux" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$DIR" submodule update --init --depth 1
+  fi
   if [ "$(uname)" = "Darwin" ]; then
     export DOCKER_BUILDKIT=1
     docker build -f tools/build/Dockerfile.builder -t vamos-builder "$DIR" \

--- a/tools/vamos
+++ b/tools/vamos
@@ -8,6 +8,16 @@ while [ -L "$SOURCE" ]; do
 done
 DIR="$(cd "$(dirname "$SOURCE")/.." >/dev/null && pwd)"
 
+prepare_kernel_volume() {
+  local linux_volume prep_container_id
+
+  linux_volume="vamos-kernel-linux"
+  prep_container_id=$(docker run -d --entrypoint tail -v "$linux_volume:/linux" vamos-builder -f /dev/null)
+
+  docker exec "$prep_container_id" sh -lc "mkdir -p /linux && chown $(id -u):$(id -g) /linux && chmod 0775 /linux"
+  docker container rm -f "$prep_container_id" >/dev/null
+}
+
 seed_kernel_workspace() {
   local linux_volume sync_container_id kernel_rev
 
@@ -15,12 +25,10 @@ seed_kernel_workspace() {
   kernel_rev="$(git -C "$DIR/kernel/linux" rev-parse HEAD)"
 
   echo "Syncing kernel/linux into Docker volume"
-  sync_container_id=$(docker run -d --entrypoint tail -v "$linux_volume:/linux" vamos-builder -f /dev/null)
+  sync_container_id=$(docker run -d --entrypoint tail -v "$DIR:/repo:ro" -v "$linux_volume:/linux" vamos-builder -f /dev/null)
 
   docker exec "$sync_container_id" sh -lc "rm -rf /linux/* /linux/.[!.]* /linux/..?*"
-
-  tar -C "$DIR/kernel/linux" -cf - . | docker exec -i "$sync_container_id" tar -xf - -C /linux
-  docker exec "$sync_container_id" sh -lc "printf '%s\n' '$kernel_rev' > /linux/.vamos-kernel-rev"
+  docker exec -u "$(id -u):$(id -g)" "$sync_container_id" sh -lc "cd /linux && git clone --no-local /repo/kernel/linux . >/dev/null 2>&1 && git checkout --force '$kernel_rev' >/dev/null 2>&1"
   docker container rm -f "$sync_container_id" >/dev/null
 }
 
@@ -33,6 +41,7 @@ setup() {
       --build-arg UID="$(id -u)" \
       --build-arg GID="$(id -g)"
     docker volume create "vamos-kernel-linux" >/dev/null
+    prepare_kernel_volume
     seed_kernel_workspace
   fi
   if [ "$(uname)" = "Linux" ]; then

--- a/tools/vamos
+++ b/tools/vamos
@@ -8,44 +8,8 @@ while [ -L "$SOURCE" ]; do
 done
 DIR="$(cd "$(dirname "$SOURCE")/.." >/dev/null && pwd)"
 
-prepare_kernel_volume() {
-  local linux_volume prep_container_id
-
-  linux_volume="vamos-kernel-linux"
-  prep_container_id=$(docker run -d --entrypoint tail -v "$linux_volume:/linux" vamos-builder -f /dev/null)
-
-  docker exec "$prep_container_id" sh -lc "mkdir -p /linux && chown $(id -u):$(id -g) /linux && chmod 0775 /linux"
-  docker container rm -f "$prep_container_id" >/dev/null
-}
-
-seed_kernel_workspace() {
-  local linux_volume sync_container_id kernel_rev
-
-  linux_volume="vamos-kernel-linux"
-  kernel_rev="$(git -C "$DIR/kernel/linux" rev-parse HEAD)"
-
-  echo "Syncing kernel/linux into Docker volume"
-  sync_container_id=$(docker run -d --entrypoint tail -v "$DIR:/repo:ro" -v "$linux_volume:/linux" vamos-builder -f /dev/null)
-
-  docker exec "$sync_container_id" sh -lc "rm -rf /linux/* /linux/.[!.]* /linux/..?*"
-  docker exec -u "$(id -u):$(id -g)" "$sync_container_id" sh -lc "cd /linux && git clone --no-local /repo/kernel/linux . >/dev/null 2>&1 && git checkout --force '$kernel_rev' >/dev/null 2>&1"
-  docker container rm -f "$sync_container_id" >/dev/null
-}
-
 setup() {
-  if ! git -C "$DIR/kernel/linux" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git -C "$DIR" submodule update --init --depth 1
-  fi
-  if [ "$(uname)" = "Darwin" ]; then
-    export DOCKER_BUILDKIT=1
-    docker build -f tools/build/Dockerfile.builder -t vamos-builder "$DIR" \
-      --build-arg UNAME="$(id -nu)" \
-      --build-arg UID="$(id -u)" \
-      --build-arg GID="$(id -g)"
-    docker volume create "vamos-kernel-linux" >/dev/null
-    prepare_kernel_volume
-    seed_kernel_workspace
-  fi
+  git -C "$DIR" submodule update --init --depth 1
   if [ "$(uname)" = "Linux" ]; then
     UDEV_RULES="/etc/udev/rules.d/99-qualcomm-edl.rules"
     if [ ! -f "$UDEV_RULES" ]; then


### PR DESCRIPTION
Docker bind mounts are really slow on macOS. So creating a docker volumes of the kernel and ccache and building on there speeds up the overall build a lot. 


| | volume | bind-mount | improvement |
| --- | --- | --- | --- |
| build from scratch | 16min 0sec  | 18min 14sec | 1.13x |
| re-build after removing out/  | 0min 42sec | 2min 6sec | 3x |
| re-build without changes | 0min 32sec | 2min 6sec | 3.9x |