### PR TITLE
kernel: enable all used i2c busses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Example: `0001-defconfig-add-vamos.patch`
 comma threex:
 - [x] ufs
 - [x] display
-- [ ] i2c
-  - [ ] TODO: look at device tree
+- [x] i2c
 - [x] wifi
   - [ ] testing (set benchmarks, test case)
 - [x] usb
@@ -59,7 +58,7 @@ comma threex:
 comma four:
 - [x] ufs
 - [x] display
-- [ ] i2c (IMU/temp/...)
+- [x] i2c (IMU/temp/...)
 - [x] wifi
   - [ ] testing (set benchmarks, test case)
 - [x] usb

--- a/kernel/dts/sdm845-comma-common.dtsi
+++ b/kernel/dts/sdm845-comma-common.dtsi
@@ -352,6 +352,33 @@
 			   <GCC_LPASS_SWAY_CLK>;
 };
 
+&gmu {
+	status = "okay";
+};
+
+&gpi_dma0 {
+	status = "okay";
+};
+
+&gpu {
+	status = "okay";
+
+	zap-shader {
+		memory-region = <&gpu_mem>;
+		firmware-name = "qcom/sdm845/a630_zap.mbn";
+	};
+};
+
+&i2c4 {
+	status = "okay";
+	clock-frequency = <400000>;
+};
+
+&i2c5 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
 &mdss {
 	status = "okay";
 };
@@ -366,21 +393,9 @@
 	vdds-supply = <&vdda_mipi_dsi0_pll>;
 };
 
-&gmu {
+&mss_pil {
 	status = "okay";
-};
-
-&gpu {
-	status = "okay";
-
-	zap-shader {
-		memory-region = <&gpu_mem>;
-		firmware-name = "qcom/sdm845/a630_zap.mbn";
-	};
-};
-
-&gpi_dma0 {
-	status = "okay";
+	firmware-name = "qcom/sdm845/mba.mbn", "qcom/sdm845/modem_nm.mbn";
 };
 
 &qupv3_id_0 {
@@ -437,11 +452,6 @@
 	vdda-pll-max-microamp = <18300>;
 };
 
-&mss_pil {
-	status = "okay";
-	firmware-name = "qcom/sdm845/mba.mbn", "qcom/sdm845/modem_nm.mbn";
-};
-
 &usb_1 {
 	status = "okay";
 };
@@ -486,6 +496,10 @@
 
 	vdda-phy-supply = <&vdda_usb2_ss_1p2>;
 	vdda-pll-supply = <&vdda_usb2_ss_core>;
+};
+
+&vreg_lvs1a_1p8 {
+	regulator-always-on;
 };
 
 &wifi {

--- a/kernel/dts/sdm845-comma-mici.dts
+++ b/kernel/dts/sdm845-comma-mici.dts
@@ -10,9 +10,6 @@
 };
 
 &i2c5 {
-	status = "okay";
-	clock-frequency = <100000>;
-
 	touchscreen@38 {
 		compatible = "focaltech,ft3168";
 		reg = <0x38>;

--- a/kernel/dts/sdm845-comma-tizi.dts
+++ b/kernel/dts/sdm845-comma-tizi.dts
@@ -21,9 +21,6 @@
 };
 
 &i2c5 {
-	status = "okay";
-	clock-frequency = <100000>;
-
 	touchscreen@17 {
 		compatible = "samsung,s6sy761";
 		reg = <0x17>;


### PR DESCRIPTION
The following i2c busses are used:

- i2c4
  - LSM6DS3 (tizi, mici)
  - MMC5603NJ (tizi only)
- i2c5
  -  touch controller (tizi, mici)
- i2c10
  - INA231 (tizi only)
  - MAX98089 (tizi only)

Also enable vreg_lvs1a_1p8 for LSM6DS3.