### PR TITLE
system: fix: set serial hostname during early boot

### DIFF
--- a/userspace/root/etc/NetworkManager/NetworkManager.conf
+++ b/userspace/root/etc/NetworkManager/NetworkManager.conf
@@ -1,7 +1,7 @@
 [main]
 plugins=ifupdown,keyfile
 dns=default
-# Hostname is set by serial-hostname service via sysctl, not /etc/hostname
+# Hostname is set by /usr/comma/set-hostname.sh during boot
 hostname-mode=none
 
 [ifupdown]

--- a/userspace/root/etc/runit/1
+++ b/userspace/root/etc/runit/1
@@ -132,11 +132,7 @@ for part in \
 done
 
 echo "=> Setting hostname..."
-if [ -f /etc/hostname ]; then
-    hostname "$(cat /etc/hostname)"
-else
-    hostname comma
-fi
+/usr/comma/set-hostname.sh
 
 echo "=> Running core services..."
 for f in /etc/runit/core-services/*.sh; do

--- a/userspace/root/usr/comma/set-hostname.sh
+++ b/userspace/root/usr/comma/set-hostname.sh
@@ -1,6 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 SERIAL="$(/usr/comma/get-serial.sh)"
-echo "serial: '$SERIAL'"
-sysctl kernel.hostname="comma-$SERIAL"
+HOSTNAME="comma"
+
+if [ -n "$SERIAL" ] && [ "$SERIAL" != "(none)" ]; then
+  HOSTNAME="comma-$SERIAL"
+fi
+
+echo "hostname: '$HOSTNAME'"
+hostname "$HOSTNAME"


### PR DESCRIPTION
Avoid reapplying the kernel default hostname from /etc/hostname during runit stage 1, which could briefly leave the system at (none) before the serial-hostname service ran.