### PR TITLE
dts: comma: pin i2c bus numbers for openpilot via aliases

### DIFF
--- a/kernel/dts/sdm845-comma-common.dtsi
+++ b/kernel/dts/sdm845-comma-common.dtsi
@@ -8,6 +8,26 @@
 / {
 	aliases {
 		serial0 = &uart9;
+
+		/*
+		 * openpilot opens fixed i2c bus numbers: IMU on bus 1
+		 * (sensord.py I2C_BUS_IMU=1), ina231 power monitor on bus 0,
+		 * touch on bus 2. Linux derives the adapter number from these
+		 * aliases (of_alias_get_id). Upstream sdm845.dtsi ships identity
+		 * aliases (i2cN=&i2cN), so without this override the IMU node
+		 * (i2c@890000 = i2c4) would be bus 4. Remap the three buses we
+		 * use to the legacy numbers and park the displaced identity
+		 * aliases on unused nodes so no two aliases target one node.
+		 *
+		 * Matches agnos legacy DTS: se10=/dev/i2c-0 (power),
+		 * se4=IMU bus 1, se5=/dev/i2c-2 (touch).
+		 */
+		i2c0 = &i2c10;	/* i2c@a88000  legacy /dev/i2c-0 (no devices on mici) */
+		i2c1 = &i2c4;	/* i2c@890000  IMU            */
+		i2c2 = &i2c5;	/* i2c@894000  touch          */
+		i2c4 = &i2c0;
+		i2c5 = &i2c1;
+		i2c10 = &i2c2;
 	};
 
 	chosen {
@@ -375,6 +395,19 @@
 };
 
 &i2c5 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+/*
+ * Legacy /dev/i2c-0 (SE10, a88000) -> aliased to bus 0 above. On the comma
+ * four this bus carries no devices openpilot uses: there is NO ina231 (legacy
+ * comma_mici.dts /delete-node's it as "not populated on mici" — confirmed on
+ * device: probe of 0x40 returns -ENXIO, bus scan empty). openpilot reads power
+ * from the PMIC bms power_supply, not this bus. Kept enabled only to preserve
+ * bus-0 numbering parity with legacy.
+ */
+&i2c10 {
 	status = "okay";
 	clock-frequency = <100000>;
 };


### PR DESCRIPTION
## What

Override the i2c `aliases` in `sdm845-comma-common.dtsi` so the touch / IMU / power buses enumerate at the bus numbers openpilot hardcodes, and enable `i2c10` so bus 0 exists.

```dts
i2c0  = &i2c10;   /* i2c@a88000  legacy /dev/i2c-0 (no devices on mici) */
i2c1  = &i2c4;    /* i2c@890000  IMU   -> bus 1 */
i2c2  = &i2c5;    /* i2c@894000  touch -> bus 2 */
i2c4  = &i2c0;    /* park displaced identity aliases on unused nodes  */
i2c5  = &i2c1;
i2c10 = &i2c2;
```

## Why

openpilot opens **fixed** i2c bus numbers — `sensord.py` hardcodes `I2C_BUS_IMU = 1`, touch is expected on bus 2, power on bus 0. Linux derives the adapter number from the DT `aliases` node (`of_alias_get_id`), and upstream `sdm845.dtsi` ships identity aliases (`i2cN=&i2cN`). With those, the IMU node (`i2c@890000` = `i2c4`) enumerates as **bus 4**, so `sensord` opens `/dev/i2c-1` and finds nothing.

The override remaps the three buses we use to the legacy numbers and reassigns the displaced identity aliases to the now-unused nodes so no two aliases target the same node (`of_alias_get_id` returns the first match). Bus assignment matches the legacy agnos DTS (`se10=/dev/i2c-0`, `se4=IMU`, `se5=/dev/i2c-2`).

`i2c10` (a88000) is enabled with no children — it's the legacy `/dev/i2c-0`; on the comma four it carries no devices openpilot uses (no `ina231` — that's a comma-three part), kept only for bus-0 numbering parity.

## Test

Flashed and verified on a comma four (mici) on mainline `6.18.0-vamos`:

- `i2c-1` → `i2c@890000`, IMU **0x6a** present (LSM6DS3TR-C, live accel/gyro/temp)
- `i2c-2` → `i2c@894000`, **ft3168** touch at 0x38 (driver bound, ABS_MT axes 0–239 × 0–535)
- `i2c-0` → `i2c@a88000`, present (empty)

Panda (`/dev/spidev0.0`) and GPS (`/dev/ttyHS0`) confirmed unaffected and working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)