### PR TITLE
WiFi bringup: in-kernel WCN3990 firmware chain (2.4 + 5 GHz)

### DIFF
--- a/kernel/configs/vamos.config
+++ b/kernel/configs/vamos.config
@@ -51,7 +51,7 @@ CONFIG_ATH10K=y
 CONFIG_ATH10K_SNOC=y
 
 # Firmware built into the kernel image (loaded before rootfs is mounted)
-CONFIG_EXTRA_FIRMWARE="regulatory.db regulatory.db.p7s"
+CONFIG_EXTRA_FIRMWARE="regulatory.db regulatory.db.p7s qcom/sdm845/mba.mbn qcom/sdm845/modem_nm.mbn ath10k/WCN3990/hw1.0/board-2.bin ath10k/WCN3990/hw1.0/firmware-5.bin ath10k/WCN3990/hw1.0/wlanmdsp.mbn"
 
 # Remoteproc / Modem
 CONFIG_QCOM_RMTFS_MEM=y
@@ -60,7 +60,13 @@ CONFIG_QCOM_SYSMON=y
 CONFIG_RPMSG_QCOM_GLINK_SMEM=y
 CONFIG_QRTR=y
 CONFIG_QRTR_SMD=y
+CONFIG_QCOM_QMI_HELPERS=y
+CONFIG_QCOM_PDR_MSG=y
 CONFIG_QCOM_PDR_HELPERS=y
+# In-kernel protection-domain mapper (answers servreg for the modem's PDs)
+CONFIG_QCOM_PD_MAPPER=y
+# In-kernel TFTP-over-QRTR server (serves wlanmdsp.mbn etc. to the modem)
+CONFIG_QCOM_TQFTPSERV=y
 CONFIG_RPMSG_CHAR=y
 CONFIG_RESET_QCOM_PDC=y
 

--- a/kernel/configs/vamos.config
+++ b/kernel/configs/vamos.config
@@ -67,6 +67,8 @@ CONFIG_QCOM_PDR_HELPERS=y
 CONFIG_QCOM_PD_MAPPER=y
 # In-kernel TFTP-over-QRTR server (serves wlanmdsp.mbn etc. to the modem)
 CONFIG_QCOM_TQFTPSERV=y
+# In-kernel rmtfs QMI service (serves the modem's EFS; read-only RAM shadow)
+CONFIG_QCOM_RMTFS_SERV=y
 CONFIG_RPMSG_CHAR=y
 CONFIG_RESET_QCOM_PDC=y
 

--- a/kernel/dts/sdm845-comma-mici.dts
+++ b/kernel/dts/sdm845-comma-mici.dts
@@ -59,3 +59,7 @@
 &uart3 {
 	status = "okay";
 };
+
+&wifi {
+	qcom,calibration-variant = "comma-mici";
+};

--- a/kernel/dts/sdm845-comma-tizi.dts
+++ b/kernel/dts/sdm845-comma-tizi.dts
@@ -63,3 +63,7 @@
 	remote-endpoint = <&panel_in>;
 	data-lanes = <0 1 2 3>;
 };
+
+&wifi {
+	qcom,calibration-variant = "comma-tizi";
+};

--- a/kernel/firmware/ath10k/WCN3990/hw1.0/board-2.bin
+++ b/kernel/firmware/ath10k/WCN3990/hw1.0/board-2.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:867e1010787764020653812167d93f5952cbbea05f576209d953d8c9322f18aa
-size 867116
+oid sha256:a6f2b5ba06d33bae9d0ec525b84b267ff0a26f4fde4e96a5b586e73096cfd769
+size 905596

--- a/kernel/firmware/ath10k/WCN3990/hw1.0/wlanmdsp.mbn
+++ b/kernel/firmware/ath10k/WCN3990/hw1.0/wlanmdsp.mbn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92e1501254e6de78c0f2e2cf091507d488b608d07e53acd14813a82744823ec2
-size 3725044
+oid sha256:aa7a7b3ef5e4c43a242e7bca199b1bb358c1111ddfc39dcdecd9eba7473feb31
+size 3379868

--- a/kernel/patches/0012-driver-squashfs-ignore-discard-mount-option.patch
+++ b/kernel/patches/0012-driver-squashfs-ignore-discard-mount-option.patch
@@ -1,0 +1,37 @@
+From: Trey Moen <trey@moen.ai>
+Subject: squashfs: accept and ignore the "discard" mount option
+
+The legacy comma AGNOS fstab mounts /persist (squashfs) with "discard".
+Old kernels ignored unknown squashfs options; the new mount API rejects
+them, failing persist.mount and dropping systemd into maintenance mode.
+Accept the flag as a no-op.
+
+diff --git a/fs/squashfs/super.c b/fs/squashfs/super.c
+index 4465cf056..cdf89c3db 100644
+--- a/fs/squashfs/super.c
++++ b/fs/squashfs/super.c
+@@ -48,6 +48,7 @@ enum Opt_errors {
+ enum squashfs_param {
+ 	Opt_errors,
+ 	Opt_threads,
++	Opt_discard,
+ };
+ 
+ struct squashfs_mount_opts {
+@@ -65,6 +66,7 @@ static const struct constant_table squashfs_param_errors[] = {
+ static const struct fs_parameter_spec squashfs_fs_parameters[] = {
+ 	fsparam_enum("errors", Opt_errors, squashfs_param_errors),
+ 	fsparam_string("threads", Opt_threads),
++	fsparam_flag("discard", Opt_discard),
+ 	{}
+ };
+ 
+@@ -142,6 +144,8 @@ static int squashfs_parse_param(struct fs_context *fc, struct fs_parameter *para
+ 		if (squashfs_parse_param_threads(param->string, opts) != 0)
+ 			return -EINVAL;
+ 		break;
++	case Opt_discard:
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}

--- a/kernel/patches/0013-driver-remoteproc-mss-auto-boot.patch
+++ b/kernel/patches/0013-driver-remoteproc-mss-auto-boot.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trey Moen <trey@moen.ai>
+Date: Wed, 1 Jul 2026 00:00:00 +0000
+Subject: remoteproc: qcom_q6v5_mss: auto-boot the modem
+
+On an unmodified legacy comma rootfs the proprietary Qualcomm daemons are
+inert, so nothing in userspace ever starts the modem. The modem is required
+to bring up the WCN3990 wlan protection domain (which publishes the QMI WLFW
+service ath10k_snoc waits on). The modem firmware is built into the kernel
+image via CONFIG_EXTRA_FIRMWARE, so no rootfs wait is needed; auto-boot as
+soon as the driver probes.
+
+---
+ drivers/remoteproc/qcom_q6v5_mss.c |  2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_mss.c b/drivers/remoteproc/qcom_q6v5_mss.c
+index 3087d895b..0e12923f6 100644
+--- a/drivers/remoteproc/qcom_q6v5_mss.c
++++ b/drivers/remoteproc/qcom_q6v5_mss.c
+@@ -2079,7 +2079,7 @@ static int q6v5_probe(struct platform_device *pdev)
+ 		return -ENOMEM;
+ 	}
+ 
+-	rproc->auto_boot = false;
++	rproc->auto_boot = true;
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+ 
+ 	qproc = rproc->priv;
+-- 
+2.53.0
+

--- a/kernel/patches/0014-driver-soc-qcom-tqftpserv.patch
+++ b/kernel/patches/0014-driver-soc-qcom-tqftpserv.patch
@@ -3,14 +3,20 @@ From: Trey Moen <trey@moen.ai>
 Date: Wed, 1 Jul 2026 00:00:01 +0000
 Subject: soc: qcom: add in-kernel TFTP-over-QRTR server (tqftpserv)
 
-Minimal read-only in-kernel reimplementation of Bjorn Andersson's userspace
-tqftpserv (https://github.com/andersson/tqftpserv). Publishes QRTR service
-4096 and serves peripheral firmware images (notably wlanmdsp.mbn) to the modem
-over TFTP-over-QRTR via the kernel firmware loader. Required to bring up the
+Minimal in-kernel reimplementation of Bjorn Andersson's userspace tqftpserv
+(https://github.com/andersson/tqftpserv). Publishes QRTR service 4096 and
+serves peripheral firmware images (notably wlanmdsp.mbn) to the modem over
+TFTP-over-QRTR via the kernel firmware loader. Required to bring up the
 WCN3990 wlan protection domain on comma devices where the proprietary Qualcomm
 userspace is inert. Supports the blksize/tsize/wsize/rsize/seek/timeoutms
-options and windowed reads, mirroring the userspace protocol behavior. Writes
-are rejected.
+options and windowed transfers, mirroring the userspace protocol behavior.
+
+WRQ (writes) are accepted into a bounded RAM-only store (1 MiB per file,
+8 MiB total, oldest evicted under pressure; nothing is written to the rootfs).
+The modem requires a successful write to its /readwrite/ area right after the
+smp2p handover before it proceeds to fetch wlanmdsp.mbn, and retries the WRQ
+in a tight loop if it is rejected. Files in the RAM store are served back for
+subsequent RRQs, checked before the firmware loader candidates.
 
 Also make QCOM_PD_MAPPER select QCOM_PDR_HELPERS so the kernel-space service
 registry (servreg) and its protection-domain helpers are built in together;
@@ -62,10 +68,10 @@ index b7f1d2a57..7903de1ee 100644
  obj-$(CONFIG_QCOM_PMIC_PDCHARGER_ULOG)	+= pmic_pdcharger_ulog.o
 diff --git a/drivers/soc/qcom/qcom_tqftpserv.c b/drivers/soc/qcom/qcom_tqftpserv.c
 new file mode 100644
-index 000000000..7c535860f
+index 000000000..bca54d82a
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_tqftpserv.c
-@@ -0,0 +1,810 @@
+@@ -0,0 +1,1193 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * In-kernel TFTP-over-QRTR server (tqftpserv).
@@ -73,14 +79,19 @@ index 000000000..7c535860f
 + * On an unmodified legacy comma rootfs the proprietary Qualcomm userspace
 + * daemons are inert, so nothing answers the TFTP-over-QRTR requests the modem
 + * issues to fetch its peripheral firmware (notably wlanmdsp.mbn, needed to
-+ * bring up the WCN3990 wlan protection domain). This is a minimal, read-only,
-+ * in-kernel reimplementation of Bjorn Andersson's userspace tqftpserv
-+ * (https://github.com/andersson/tqftpserv) that serves those files out of the
-+ * kernel firmware loader (request_firmware()).
++ * bring up the WCN3990 wlan protection domain). This is a minimal in-kernel
++ * reimplementation of Bjorn Andersson's userspace tqftpserv
++ * (https://github.com/andersson/tqftpserv) that serves read requests out of
++ * the kernel firmware loader (request_firmware()) and accepts write requests
++ * into a bounded RAM-only store (the modem insists on a successful write to
++ * its /readwrite/ area right after boot before it proceeds to fetch
++ * wlanmdsp.mbn; nothing is ever written to the rootfs).
 + *
-+ * It publishes QRTR service 4096 (version 1, instance 0) and handles TFTP RRQ
-+ * transfers, mirroring the userspace protocol behavior (blksize/tsize/wsize/
-+ * rsize/seek/timeoutms options, windowed reads). Writes are not supported.
++ * It publishes QRTR service 4096 (version 1, instance 0) and handles TFTP
++ * RRQ and WRQ transfers, mirroring the userspace protocol behavior (blksize/
++ * tsize/wsize/rsize/seek/timeoutms options, windowed transfers). Files
++ * written by the modem are kept in RAM, keyed by their virtual path, and are
++ * served back for subsequent RRQs (checked before the firmware loader).
 + *
 + * Copyright (c) 2018, Linaro Ltd. (protocol reference)
 + */
@@ -142,13 +153,17 @@ index 000000000..7c535860f
 +#define MAX_TIMEOUTMS	255000
 +#define MIN_SEEK	0
 +
++/* RAM-only write store limits */
++#define RAM_FILE_MAX	(1024 * 1024)		/* 1 MiB per file */
++#define RAM_TOTAL_MAX	(8 * 1024 * 1024)	/* 8 MiB total */
++#define RAM_PATH_MAX	256
++
 +/* Path prefixes that map into the kernel firmware search path */
 +static const char * const readonly_prefixes[] = {
 +	"/readonly/vendor/firmware/",
 +	"/readonly/firmware/image/",
 +	"/readonly/vendor/firmware_mnt/image/",
 +};
-+#define READWRITE_PREFIX	"/readwrite/"
 +
 +/* Candidate directory prefixes for request_firmware(), in priority order.
 + * The first two match the built-in EXTRA_FIRMWARE blobs; the bare name
@@ -160,13 +175,41 @@ index 000000000..7c535860f
 +	"",
 +};
 +
++/*
++ * A file written by the modem, kept in RAM only. Keyed by the virtual TFTP
++ * path (e.g. "/readwrite/..."). Newest entries at the head of ram_files;
++ * evicted from the tail under memory pressure.
++ */
++struct ram_file {
++	struct list_head node;
++	char *path;
++	u8 *data;
++	size_t size;
++};
++
++static LIST_HEAD(ram_files);
++static size_t ram_total;
++
 +struct tftp_client {
 +	struct list_head node;
 +
 +	struct socket *sock;
 +	struct sockaddr_qrtr sq;	/* peer address */
 +
-+	const struct firmware *fw;
++	bool writer;
++
++	/* reader state: the file being served */
++	const struct firmware *fw;	/* if backed by request_firmware() */
++	u8 *owned;			/* if backed by a RAM store copy */
++	const u8 *data;
++	size_t size;
++
++	/* writer state: the file being received */
++	char *path;
++	u8 *wbuf;
++	size_t wbuf_cap;
++	size_t wsize_recv;		/* bytes received so far */
++	u32 blocks_recv;		/* block counter (no u16 wraparound) */
 +
 +	size_t blksize;
 +	size_t rsize;
@@ -180,7 +223,7 @@ index 000000000..7c535860f
 +static struct task_struct *tqftp_thread;
 +static struct socket *tqftp_ctrl_sock;
 +static struct sockaddr_qrtr tqftp_local;	/* our own node/port */
-+static LIST_HEAD(readers);
++static LIST_HEAD(clients);
 +
 +/* Woken by sk_data_ready on any of our sockets */
 +static DECLARE_WAIT_QUEUE_HEAD(tqftp_waitq);
@@ -190,6 +233,71 @@ index 000000000..7c535860f
 +{
 +	atomic_set(&tqftp_wake, 1);
 +	wake_up_interruptible(&tqftp_waitq);
++}
++
++/* ---- RAM store (all accesses from the tqftpserv kthread only) ---- */
++
++static struct ram_file *ram_store_lookup(const char *path)
++{
++	struct ram_file *rf;
++
++	list_for_each_entry(rf, &ram_files, node) {
++		if (!strcmp(rf->path, path))
++			return rf;
++	}
++	return NULL;
++}
++
++static void ram_store_free(struct ram_file *rf)
++{
++	list_del(&rf->node);
++	ram_total -= rf->size;
++	kvfree(rf->data);
++	kfree(rf->path);
++	kfree(rf);
++}
++
++/* Store (or replace) a file; copies @data. */
++static int ram_store_put(const char *path, const u8 *data, size_t size)
++{
++	struct ram_file *rf;
++	u8 *copy;
++
++	if (size > RAM_FILE_MAX)
++		return -ENOSPC;
++
++	rf = ram_store_lookup(path);
++	if (rf)
++		ram_store_free(rf);
++
++	/* Evict oldest entries until the new file fits */
++	while (ram_total + size > RAM_TOTAL_MAX && !list_empty(&ram_files)) {
++		rf = list_last_entry(&ram_files, struct ram_file, node);
++		pr_info("RAM store full, evicting '%s' (%zu bytes)\n",
++			rf->path, rf->size);
++		ram_store_free(rf);
++	}
++
++	rf = kzalloc(sizeof(*rf), GFP_KERNEL);
++	if (!rf)
++		return -ENOMEM;
++
++	rf->path = kstrdup(path, GFP_KERNEL);
++	copy = kvmalloc(size ? size : 1, GFP_KERNEL);
++	if (!rf->path || !copy) {
++		kvfree(copy);
++		kfree(rf->path);
++		kfree(rf);
++		return -ENOMEM;
++	}
++
++	memcpy(copy, data, size);
++	rf->data = copy;
++	rf->size = size;
++	list_add(&rf->node, &ram_files);
++	ram_total += size;
++
++	return 0;
 +}
 +
 +/* ---- low level QRTR socket helpers ---- */
@@ -280,10 +388,18 @@ index 000000000..7c535860f
 +	sock_release(sock);
 +}
 +
++static int tftp_send_ack(struct socket *sock, const struct sockaddr_qrtr *dst,
++			 u16 block)
++{
++	u8 ack[4] = { 0, OP_ACK, (block >> 8) & 0xff, block & 0xff };
++
++	return tqftp_sendto(sock, ack, sizeof(ack), dst);
++}
++
 +/*
 + * tftp_send_data() - send one DATA block to the client.
 + * @block: 1-based TFTP block number
-+ * @offset: byte offset into the firmware image (already includes seek)
++ * @offset: byte offset into the file (already includes seek)
 + * @response_size: if non-zero, cap the payload to this many bytes (rsize path)
 + *
 + * Returns the number of payload bytes placed in the packet (0..blksize) on
@@ -303,10 +419,10 @@ index 000000000..7c535860f
 +	*p++ = (block >> 8) & 0xff;
 +	*p++ = block & 0xff;
 +
-+	if (offset >= client->fw->size)
++	if (offset >= client->size)
 +		avail = 0;
 +	else
-+		avail = client->fw->size - offset;
++		avail = client->size - offset;
 +
 +	payload = min(avail, client->blksize);
 +
@@ -320,7 +436,7 @@ index 000000000..7c535860f
 +	}
 +
 +	if (payload)
-+		memcpy(p, client->fw->data + offset, payload);
++		memcpy(p, client->data + offset, payload);
 +	p += payload;
 +
 +	ret = tqftp_sendto(client->sock, buf, p - buf, &client->sq);
@@ -374,7 +490,7 @@ index 000000000..7c535860f
 +}
 +
 +/*
-+ * parse_options() - parse the option list trailing an RRQ.
++ * parse_options() - parse the option list trailing an RRQ/WRQ.
 + * Mirrors andersson/tqftpserv parse_options(): NUL-separated opt/value pairs.
 + */
 +static int parse_options(const char *buf, size_t len, size_t *blksize,
@@ -439,22 +555,45 @@ index 000000000..7c535860f
 +}
 +
 +/*
-+ * translate_path() - map a virtual TFTP path to a firmware image.
++ * parse_request_header() - parse filename + mode from an RRQ/WRQ packet.
++ * Returns a pointer to the first option byte (or the buffer end) on success,
++ * NULL on a malformed packet. *filename and *mode point into @buf.
++ */
++static const char *parse_request_header(const char *buf, size_t len,
++					const char **filename, const char **mode)
++{
++	const char *end = buf + len;
++	const char *p = buf + 2;
++	size_t n;
++
++	*filename = p;
++	n = strnlen(p, end - p);
++	if (n == (size_t)(end - p))
++		return NULL;
++	p += n + 1;
++
++	if (p >= end)
++		return NULL;
++	*mode = p;
++	n = strnlen(p, end - p);
++	if (n == (size_t)(end - p))
++		return NULL;
++	p += n + 1;
++
++	return p;
++}
++
++/*
++ * translate_path() - map a virtual read path to a firmware image.
 + *
-+ * Strips a known readonly prefix, rejects path traversal, then tries
-+ * request_firmware() with each candidate directory prefix in order. On
-+ * success stores the firmware in *out_fw. Returns 0 on success.
++ * Strips a known readonly prefix, then tries request_firmware() with each
++ * candidate directory prefix in order. Returns 0 on success.
 + */
 +static int translate_path(const char *path, const struct firmware **out_fw)
 +{
 +	const char *rel = NULL;
 +	char name[256];
 +	int i;
-+
-+	if (!strncmp(path, READWRITE_PREFIX, strlen(READWRITE_PREFIX))) {
-+		pr_info("write path '%s' rejected (read-only server)\n", path);
-+		return -EACCES;
-+	}
 +
 +	for (i = 0; i < ARRAY_SIZE(readonly_prefixes); i++) {
 +		size_t plen = strlen(readonly_prefixes[i]);
@@ -466,13 +605,9 @@ index 000000000..7c535860f
 +	}
 +
 +	if (!rel) {
-+		pr_info("path '%s' has no known prefix, rejecting\n", path);
++		pr_info_ratelimited("path '%s' has no known prefix, rejecting\n",
++				    path);
 +		return -ENOENT;
-+	}
-+
-+	if (strstr(rel, "..")) {
-+		pr_info("path traversal in '%s' rejected\n", path);
-+		return -EACCES;
 +	}
 +
 +	for (i = 0; i < ARRAY_SIZE(fw_dir_prefixes); i++) {
@@ -490,7 +625,7 @@ index 000000000..7c535860f
 +		}
 +	}
 +
-+	pr_info("no firmware found for '%s' (rel '%s')\n", path, rel);
++	pr_info_ratelimited("no firmware found for '%s' (rel '%s')\n", path, rel);
 +	return -ENOENT;
 +}
 +
@@ -499,19 +634,58 @@ index 000000000..7c535860f
 +	list_del(&client->node);
 +	if (client->fw)
 +		release_firmware(client->fw);
++	kvfree(client->owned);
++	kvfree(client->wbuf);
++	kfree(client->path);
 +	if (client->sock)
 +		sock_release(client->sock);
 +	kfree(client->blk_buf);
 +	kfree(client);
 +}
 +
++static struct tftp_client *client_new(const struct sockaddr_qrtr *sq,
++				      size_t blksize, size_t rsize,
++				      size_t wsize, unsigned int timeoutms,
++				      loff_t seek)
++{
++	struct tftp_client *client;
++	struct socket *sock;
++
++	sock = tqftp_open_sock(NULL);
++	if (IS_ERR(sock))
++		return NULL;
++
++	client = kzalloc(sizeof(*client), GFP_KERNEL);
++	if (!client) {
++		sock_release(sock);
++		return NULL;
++	}
++
++	client->blk_buf = kzalloc(blksize + 4, GFP_KERNEL);
++	if (!client->blk_buf) {
++		kfree(client);
++		sock_release(sock);
++		return NULL;
++	}
++
++	client->sock = sock;
++	client->sq = *sq;
++	client->blksize = blksize;
++	client->rsize = rsize;
++	client->wsize = wsize;
++	client->timeoutms = timeoutms;
++	client->seek = seek;
++
++	list_add(&client->node, &clients);
++	return client;
++}
++
 +static void handle_rrq(const char *buf, size_t len, const struct sockaddr_qrtr *sq)
 +{
 +	struct tftp_client *client;
 +	const char *end = buf + len;
-+	const char *p = buf + 2;
 +	const char *filename, *mode;
-+	size_t filename_len, mode_len;
++	const char *p;
 +	ssize_t tsize = -1;
 +	size_t blksize = 512;
 +	unsigned int timeoutms = 1000;
@@ -519,101 +693,96 @@ index 000000000..7c535860f
 +	size_t wsize = 1;
 +	loff_t seek = 0;
 +	bool do_oack = false;
-+	struct socket *sock;
 +	const struct firmware *fw = NULL;
++	struct ram_file *rf;
++	u8 *owned = NULL;
++	const u8 *data;
++	size_t size;
 +	int ret;
 +
-+	filename = p;
-+	filename_len = strnlen(filename, end - p);
-+	if (filename_len == (size_t)(end - p)) {
-+		pr_err("RRQ: filename not NUL-terminated\n");
++	p = parse_request_header(buf, len, &filename, &mode);
++	if (!p) {
++		pr_err_ratelimited("RRQ: malformed packet\n");
 +		return;
 +	}
-+	p += filename_len + 1;
-+
-+	if (p >= end) {
-+		pr_err("RRQ: missing mode\n");
-+		return;
-+	}
-+	mode = p;
-+	mode_len = strnlen(mode, end - p);
-+	if (mode_len == (size_t)(end - p)) {
-+		pr_err("RRQ: mode not NUL-terminated\n");
-+		return;
-+	}
-+	p += mode_len + 1;
 +
 +	if (strcasecmp(mode, "octet")) {
-+		pr_err("RRQ: unsupported mode '%s'\n", mode);
++		pr_err_ratelimited("RRQ: unsupported mode '%s'\n", mode);
 +		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
 +		return;
 +	}
 +
-+	pr_info("RRQ '%s' (mode %s) from %d:%d\n",
-+		filename, mode, sq->sq_node, sq->sq_port);
++	if (strstr(filename, "..")) {
++		pr_info_ratelimited("RRQ: path traversal in '%s' rejected\n",
++				    filename);
++		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
++		return;
++	}
++
++	pr_info("RRQ '%s' from %d:%d\n", filename, sq->sq_node, sq->sq_port);
 +
 +	if (p < end) {
 +		do_oack = true;
 +		ret = parse_options(p, end - p, &blksize, &tsize, &wsize,
 +				    &timeoutms, &rsize, &seek);
 +		if (ret < 0) {
-+			pr_err("RRQ: bad options, rejecting\n");
++			pr_err_ratelimited("RRQ: bad options, rejecting\n");
 +			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG,
 +					   "Option negotiation failed");
 +			return;
 +		}
 +	}
 +
-+	ret = translate_path(filename, &fw);
-+	if (ret < 0) {
-+		tftp_send_error_to(sq, TFTP_ERROR_ENOENT, "file not found");
-+		return;
++	/*
++	 * The RAM store (files the modem wrote earlier) takes priority over
++	 * the firmware loader: the modem may read back what it wrote. Copy
++	 * the data so an eviction by a completing write can't pull it out
++	 * from under an in-flight transfer.
++	 */
++	rf = ram_store_lookup(filename);
++	if (rf) {
++		owned = kvmalloc(rf->size ? rf->size : 1, GFP_KERNEL);
++		if (!owned)
++			return;
++		memcpy(owned, rf->data, rf->size);
++		data = owned;
++		size = rf->size;
++		pr_info("serving '%s' from RAM store (%zu bytes)\n",
++			filename, size);
++	} else {
++		ret = translate_path(filename, &fw);
++		if (ret < 0) {
++			tftp_send_error_to(sq, TFTP_ERROR_ENOENT, "file not found");
++			return;
++		}
++		data = fw->data;
++		size = fw->size;
 +	}
 +
 +	if (tsize != -1)
-+		tsize = fw->size;
++		tsize = size;
 +
-+	sock = tqftp_open_sock(NULL);
-+	if (IS_ERR(sock)) {
-+		release_firmware(fw);
-+		return;
-+	}
-+
-+	client = kzalloc(sizeof(*client), GFP_KERNEL);
++	client = client_new(sq, blksize, rsize, wsize, timeoutms, seek);
 +	if (!client) {
-+		sock_release(sock);
 +		release_firmware(fw);
++		kvfree(owned);
 +		return;
 +	}
 +
-+	client->blk_buf = kzalloc(blksize + 4, GFP_KERNEL);
-+	if (!client->blk_buf) {
-+		kfree(client);
-+		sock_release(sock);
-+		release_firmware(fw);
-+		return;
-+	}
-+
-+	client->sock = sock;
-+	client->sq = *sq;
 +	client->fw = fw;
-+	client->blksize = blksize;
-+	client->rsize = rsize;
-+	client->wsize = wsize;
-+	client->timeoutms = timeoutms;
-+	client->seek = seek;
++	client->owned = owned;
++	client->data = data;
++	client->size = size;
 +
-+	pr_info("'%s' opened (blksize=%zu wsize=%zu rsize=%zu seek=%lld)\n",
++	pr_info("'%s' opened for reading (blksize=%zu wsize=%zu rsize=%zu seek=%lld)\n",
 +		filename, blksize, wsize, rsize, (long long)seek);
-+
-+	list_add(&client->node, &readers);
 +
 +	if (do_oack) {
 +		/*
 +		 * Options were negotiated: reply with OACK. The client then
 +		 * ACKs block 0, driving the windowed transfer in handle_reader.
 +		 */
-+		tftp_send_oack(sock, sq, &blksize,
++		tftp_send_oack(client->sock, sq, &blksize,
 +			       tsize ? &tsize : NULL,
 +			       wsize ? &wsize : NULL,
 +			       &client->timeoutms,
@@ -625,6 +794,99 @@ index 000000000..7c535860f
 +	}
 +}
 +
++static void handle_wrq(const char *buf, size_t len, const struct sockaddr_qrtr *sq)
++{
++	struct tftp_client *client;
++	const char *end = buf + len;
++	const char *filename, *mode;
++	const char *p;
++	ssize_t tsize = -1;
++	size_t blksize = 512;
++	unsigned int timeoutms = 1000;
++	size_t rsize = 0;
++	size_t wsize = 1;
++	loff_t seek = 0;
++	bool do_oack = false;
++	size_t prealloc;
++	int ret;
++
++	p = parse_request_header(buf, len, &filename, &mode);
++	if (!p) {
++		pr_err_ratelimited("WRQ: malformed packet\n");
++		return;
++	}
++
++	if (strcasecmp(mode, "octet")) {
++		pr_err_ratelimited("WRQ: unsupported mode '%s'\n", mode);
++		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
++		return;
++	}
++
++	if (strstr(filename, "..") || strlen(filename) >= RAM_PATH_MAX) {
++		pr_info_ratelimited("WRQ: invalid path '%s' rejected\n", filename);
++		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
++		return;
++	}
++
++	if (p < end) {
++		do_oack = true;
++		ret = parse_options(p, end - p, &blksize, &tsize, &wsize,
++				    &timeoutms, &rsize, &seek);
++		if (ret < 0) {
++			pr_err_ratelimited("WRQ: bad options, rejecting\n");
++			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG,
++					   "Option negotiation failed");
++			return;
++		}
++	}
++
++	if (tsize > RAM_FILE_MAX) {
++		pr_warn_ratelimited("WRQ '%s': tsize %zd exceeds %d byte cap, rejecting\n",
++				    filename, tsize, RAM_FILE_MAX);
++		tftp_send_error_to(sq, TFTP_ERROR_ENOSPACE,
++				   "File too large for RAM store");
++		return;
++	}
++
++	pr_info("WRQ '%s' from %d:%d (blksize=%zu wsize=%zu tsize=%zd)\n",
++		filename, sq->sq_node, sq->sq_port, blksize, wsize, tsize);
++
++	client = client_new(sq, blksize, rsize, wsize, timeoutms, seek);
++	if (!client)
++		return;
++
++	client->writer = true;
++	client->path = kstrdup(filename, GFP_KERNEL);
++	if (!client->path) {
++		client_free(client);
++		return;
++	}
++
++	/* Preallocate based on announced tsize, else one window. */
++	if (tsize > 0)
++		prealloc = tsize;
++	else
++		prealloc = min_t(size_t, blksize * wsize, RAM_FILE_MAX);
++	if (prealloc) {
++		client->wbuf = kvzalloc(prealloc, GFP_KERNEL);
++		if (!client->wbuf) {
++			client_free(client);
++			return;
++		}
++		client->wbuf_cap = prealloc;
++	}
++
++	if (do_oack)
++		tftp_send_oack(client->sock, sq, &blksize,
++			       tsize != -1 ? &tsize : NULL,
++			       wsize ? &wsize : NULL,
++			       &client->timeoutms,
++			       rsize ? &rsize : NULL,
++			       seek ? &seek : NULL);
++	else
++		tftp_send_ack(client->sock, sq, 0);
++}
++
 +/*
 + * handle_reader() - process one ACK from a client and send the next window.
 + *
@@ -632,7 +894,8 @@ index 000000000..7c535860f
 + * @last we send blocks [last+1 .. last+wsize], each optionally capped by
 + * rsize. seek shifts the file offset. Returns:
 + *   <= 0 : transfer complete or failed, caller frees the client
-+ *   > 0  : window sent, keep the client alive
++ *   1    : no more queued packets (EAGAIN), keep the client alive
++ *   2    : packet consumed, poll the socket again
 + */
 +static int handle_reader(struct tftp_client *client)
 +{
@@ -645,6 +908,8 @@ index 000000000..7c535860f
 +	int n = 0;
 +
 +	len = tqftp_recvfrom(client->sock, buf, sizeof(buf), &sq);
++	if (len == -EAGAIN)
++		return 1;
 +	if (len < 0)
 +		return -1;
 +
@@ -704,10 +969,127 @@ index 000000000..7c535860f
 +			break;
 +	}
 +
-+	return 1;
++	return 2;
 +}
 +
-+/* Decode a QRTR control packet on the control socket (only BYE matters). */
++/*
++ * handle_writer() - process one DATA packet from a writing client.
++ *
++ * Mirrors andersson/tqftpserv handle_writer(): expect DATA blocks in strict
++ * sequence; ACK when a full window completes (block % wsize == 0) or when the
++ * final short block arrives (RFC 7440 windowed semantics). The transfer
++ * completes when a payload shorter than blksize is received, at which point
++ * the file is committed to the RAM store. Returns:
++ *   <= 0 : transfer complete or failed, caller frees the client
++ *   1    : no more queued packets (EAGAIN), keep the client alive
++ *   2    : block consumed, poll the socket again
++ */
++static int handle_writer(struct tftp_client *client)
++{
++	struct sockaddr_qrtr sq;
++	u8 *buf = client->blk_buf;
++	size_t payload;
++	size_t offset;
++	u16 block;
++	int opcode;
++	int len;
++
++	len = tqftp_recvfrom(client->sock, buf, client->blksize + 4, &sq);
++	if (len == -EAGAIN)
++		return 1;
++	if (len < 0)
++		return -1;
++
++	/* Drop unsolicited/spoofed messages */
++	if (sq.sq_node != client->sq.sq_node ||
++	    sq.sq_port != client->sq.sq_port)
++		return -1;
++
++	if (len < 4)
++		return -1;
++
++	opcode = buf[0] << 8 | buf[1];
++	block = buf[2] << 8 | buf[3];
++
++	if (opcode == OP_ERROR) {
++		pr_err("writer got remote error %d\n", block);
++		return -1;
++	}
++	if (opcode != OP_DATA) {
++		pr_err("expected DATA opcode, got %d\n", opcode);
++		tftp_send_error(client->sock, &client->sq,
++				TFTP_ERROR_EBADOP, "Expected DATA opcode");
++		return -1;
++	}
++
++	/* Strict in-sequence delivery, like the userspace implementation */
++	if (block != (u16)(client->blocks_recv + 1)) {
++		pr_err("block out of sequence: %u (expected %u)\n",
++		       block, (u16)(client->blocks_recv + 1));
++		tftp_send_error(client->sock, &client->sq,
++				TFTP_ERROR_EBADOP, "Block number out of sequence");
++		return -1;
++	}
++
++	payload = len - 4;
++	offset = (size_t)client->blocks_recv * client->blksize;
++
++	if (offset + payload > RAM_FILE_MAX) {
++		pr_warn("WRQ '%s': exceeds %d byte cap, aborting\n",
++			client->path, RAM_FILE_MAX);
++		tftp_send_error(client->sock, &client->sq,
++				TFTP_ERROR_ENOSPACE, "File too large for RAM store");
++		return -1;
++	}
++
++	if (offset + payload > client->wbuf_cap) {
++		size_t new_cap = max_t(size_t, client->wbuf_cap * 2,
++				       offset + payload);
++		u8 *nbuf;
++
++		new_cap = min_t(size_t, new_cap, RAM_FILE_MAX);
++		nbuf = kvzalloc(new_cap, GFP_KERNEL);
++		if (!nbuf) {
++			tftp_send_error(client->sock, &client->sq,
++					TFTP_ERROR_ENOSPACE, "Out of memory");
++			return -1;
++		}
++		if (client->wbuf)
++			memcpy(nbuf, client->wbuf, client->wsize_recv);
++		kvfree(client->wbuf);
++		client->wbuf = nbuf;
++		client->wbuf_cap = new_cap;
++	}
++
++	if (payload)
++		memcpy(client->wbuf + offset, buf + 4, payload);
++	client->blocks_recv++;
++	client->wsize_recv = max(client->wsize_recv, offset + payload);
++
++	pr_debug("got block %u (%zu bytes) for '%s'\n",
++		 block, payload, client->path);
++
++	/* ACK at the end of each window or on the final short block */
++	if ((client->blocks_recv % client->wsize) == 0 ||
++	    payload < client->blksize)
++		tftp_send_ack(client->sock, &client->sq, block);
++
++	if (payload < client->blksize) {
++		int ret = ram_store_put(client->path, client->wbuf,
++					client->wsize_recv);
++		if (ret < 0)
++			pr_warn("failed to store '%s': %d\n",
++				client->path, ret);
++		else
++			pr_info("WRQ '%s' complete: %zu bytes stored in RAM (store total %zu)\n",
++				client->path, client->wsize_recv, ram_total);
++		return 0;
++	}
++
++	return 2;
++}
++
++/* Decode a QRTR control packet on the control socket. */
 +static void handle_ctrl(const void *buf, size_t len, const struct sockaddr_qrtr *sq)
 +{
 +	const struct qrtr_ctrl_pkt *pkt = buf;
@@ -719,7 +1101,7 @@ index 000000000..7c535860f
 +
 +	cmd = le32_to_cpu(pkt->cmd);
 +	if (cmd == QRTR_TYPE_BYE) {
-+		list_for_each_entry_safe(client, next, &readers, node) {
++		list_for_each_entry_safe(client, next, &clients, node) {
 +			if (client->sq.sq_node == sq->sq_node)
 +				client_free(client);
 +		}
@@ -727,7 +1109,7 @@ index 000000000..7c535860f
 +		u32 node = le32_to_cpu(pkt->client.node);
 +		u32 port = le32_to_cpu(pkt->client.port);
 +
-+		list_for_each_entry_safe(client, next, &readers, node) {
++		list_for_each_entry_safe(client, next, &clients, node) {
 +			if (client->sq.sq_node == node &&
 +			    client->sq.sq_port == port)
 +				client_free(client);
@@ -758,18 +1140,16 @@ index 000000000..7c535860f
 +			handle_rrq(buf, len, &sq);
 +			break;
 +		case OP_WRQ:
-+			pr_info("WRQ from %d:%d rejected (read-only server)\n",
-+				sq.sq_node, sq.sq_port);
-+			tftp_send_error_to(&sq, TFTP_ERROR_EACCESS,
-+					   "Write not supported");
++			handle_wrq(buf, len, &sq);
 +			break;
 +		case OP_ERROR:
-+			pr_err("error %d from %d:%d\n",
-+			       buf[2] << 8 | buf[3], sq.sq_node, sq.sq_port);
++			pr_err_ratelimited("error %d from %d:%d\n",
++					   buf[2] << 8 | buf[3],
++					   sq.sq_node, sq.sq_port);
 +			break;
 +		default:
-+			pr_err("unhandled op %d from %d:%d\n",
-+			       opcode, sq.sq_node, sq.sq_port);
++			pr_err_ratelimited("unhandled op %d from %d:%d\n",
++					   opcode, sq.sq_node, sq.sq_port);
 +			break;
 +		}
 +	}
@@ -835,10 +1215,15 @@ index 000000000..7c535860f
 +		/*
 +		 * A single sk_data_ready fires for whichever socket got data;
 +		 * we don't know which, so drain them all (mirrors the userspace
-+		 * select() loop servicing every ready fd).
++		 * select() loop servicing every ready fd). Several packets can
++		 * be queued per socket (windowed transfers), so drain each
++		 * client until it returns EAGAIN or completes.
 +		 */
-+		list_for_each_entry_safe(client, next, &readers, node) {
-+			ret = handle_reader(client);
++		list_for_each_entry_safe(client, next, &clients, node) {
++			do {
++				ret = client->writer ? handle_writer(client)
++						     : handle_reader(client);
++			} while (ret == 2);
 +			if (ret <= 0)
 +				client_free(client);
 +		}
@@ -846,7 +1231,7 @@ index 000000000..7c535860f
 +		service_ctrl_sock();
 +	}
 +
-+	list_for_each_entry_safe(client, next, &readers, node)
++	list_for_each_entry_safe(client, next, &clients, node)
 +		client_free(client);
 +
 +	return 0;
@@ -864,10 +1249,14 @@ index 000000000..7c535860f
 +
 +static void __exit tqftp_exit(void)
 +{
++	struct ram_file *rf, *next;
++
 +	if (tqftp_thread)
 +		kthread_stop(tqftp_thread);
 +	if (tqftp_ctrl_sock && !IS_ERR(tqftp_ctrl_sock))
 +		sock_release(tqftp_ctrl_sock);
++	list_for_each_entry_safe(rf, next, &ram_files, node)
++		ram_store_free(rf);
 +}
 +
 +/* late_initcall: run after qrtr (subsys/module init) is up. */

--- a/kernel/patches/0014-driver-soc-qcom-tqftpserv.patch
+++ b/kernel/patches/0014-driver-soc-qcom-tqftpserv.patch
@@ -1,0 +1,881 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trey Moen <trey@moen.ai>
+Date: Wed, 1 Jul 2026 00:00:01 +0000
+Subject: soc: qcom: add in-kernel TFTP-over-QRTR server (tqftpserv)
+
+Minimal read-only in-kernel reimplementation of Bjorn Andersson's userspace
+tqftpserv (https://github.com/andersson/tqftpserv). Publishes QRTR service
+4096 and serves peripheral firmware images (notably wlanmdsp.mbn) to the modem
+over TFTP-over-QRTR via the kernel firmware loader. Required to bring up the
+WCN3990 wlan protection domain on comma devices where the proprietary Qualcomm
+userspace is inert. Supports the blksize/tsize/wsize/rsize/seek/timeoutms
+options and windowed reads, mirroring the userspace protocol behavior. Writes
+are rejected.
+
+Also make QCOM_PD_MAPPER select QCOM_PDR_HELPERS so the kernel-space service
+registry (servreg) and its protection-domain helpers are built in together;
+this keeps PDR_HELPERS=y on a modules-less rootfs.
+
+---
+diff --git a/drivers/soc/qcom/Kconfig b/drivers/soc/qcom/Kconfig
+index 2caadbbcf..0922d0cb5 100644
+--- a/drivers/soc/qcom/Kconfig
++++ b/drivers/soc/qcom/Kconfig
+@@ -75,6 +75,7 @@ config QCOM_OCMEM
+ config QCOM_PD_MAPPER
+ 	tristate "Qualcomm Protection Domain Mapper"
+ 	select QCOM_QMI_HELPERS
++	select QCOM_PDR_HELPERS
+ 	select QCOM_PDR_MSG
+ 	select AUXILIARY_BUS
+ 	depends on NET && QRTR && (ARCH_QCOM || COMPILE_TEST)
+@@ -94,6 +95,18 @@ config QCOM_PDR_HELPERS
+ config QCOM_PDR_MSG
+ 	tristate
+ 
++config QCOM_TQFTPSERV
++	tristate "Qualcomm in-kernel TFTP-over-QRTR server"
++	depends on NET && QRTR
++	select FW_LOADER
++	help
++	  In-kernel reimplementation of the userspace tqftpserv daemon. It
++	  publishes QRTR service 4096 and serves peripheral firmware images
++	  (e.g. wlanmdsp.mbn) to the modem over TFTP-over-QRTR using the kernel
++	  firmware loader. This is needed to bring up the WCN3990 wlan
++	  protection domain on systems where the proprietary Qualcomm userspace
++	  is not present. Read-only; writes are rejected.
++
+ config QCOM_PMIC_PDCHARGER_ULOG
+ 	tristate "Qualcomm PMIC PDCharger ULOG driver"
+ 	depends on RPMSG
+diff --git a/drivers/soc/qcom/Makefile b/drivers/soc/qcom/Makefile
+index b7f1d2a57..7903de1ee 100644
+--- a/drivers/soc/qcom/Makefile
++++ b/drivers/soc/qcom/Makefile
+@@ -10,6 +10,7 @@ obj-$(CONFIG_QCOM_OCMEM)	+= ocmem.o
+ obj-$(CONFIG_QCOM_PD_MAPPER)	+= qcom_pd_mapper.o
+ obj-$(CONFIG_QCOM_PDR_HELPERS)	+= pdr_interface.o
+ obj-$(CONFIG_QCOM_PDR_MSG)	+= qcom_pdr_msg.o
++obj-$(CONFIG_QCOM_TQFTPSERV)	+= qcom_tqftpserv.o
+ obj-$(CONFIG_QCOM_PMIC_GLINK)	+= pmic_glink.o
+ obj-$(CONFIG_QCOM_PMIC_GLINK)	+= pmic_glink_altmode.o
+ obj-$(CONFIG_QCOM_PMIC_PDCHARGER_ULOG)	+= pmic_pdcharger_ulog.o
+diff --git a/drivers/soc/qcom/qcom_tqftpserv.c b/drivers/soc/qcom/qcom_tqftpserv.c
+new file mode 100644
+index 000000000..7c535860f
+--- /dev/null
++++ b/drivers/soc/qcom/qcom_tqftpserv.c
+@@ -0,0 +1,810 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * In-kernel TFTP-over-QRTR server (tqftpserv).
++ *
++ * On an unmodified legacy comma rootfs the proprietary Qualcomm userspace
++ * daemons are inert, so nothing answers the TFTP-over-QRTR requests the modem
++ * issues to fetch its peripheral firmware (notably wlanmdsp.mbn, needed to
++ * bring up the WCN3990 wlan protection domain). This is a minimal, read-only,
++ * in-kernel reimplementation of Bjorn Andersson's userspace tqftpserv
++ * (https://github.com/andersson/tqftpserv) that serves those files out of the
++ * kernel firmware loader (request_firmware()).
++ *
++ * It publishes QRTR service 4096 (version 1, instance 0) and handles TFTP RRQ
++ * transfers, mirroring the userspace protocol behavior (blksize/tsize/wsize/
++ * rsize/seek/timeoutms options, windowed reads). Writes are not supported.
++ *
++ * Copyright (c) 2018, Linaro Ltd. (protocol reference)
++ */
++
++#define pr_fmt(fmt) "tqftpserv: " fmt
++
++#include <linux/firmware.h>
++#include <linux/kernel.h>
++#include <linux/kthread.h>
++#include <linux/list.h>
++#include <linux/module.h>
++#include <linux/net.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <net/sock.h>
++
++#include <linux/soc/qcom/qmi.h>
++#include <uapi/linux/qrtr.h>
++
++/* QRTR service registration for the TFTP server. Mirror andersson/tqftpserv:
++ * qrtr_publish(fd, 4096, 1, 0) => service 4096, version 1, instance 0.
++ */
++#define TQFTP_SERVICE		4096
++#define TQFTP_VERSION		1
++#define TQFTP_INSTANCE		0
++
++/* TFTP opcodes (RFC 1350 + RFC 2347 OACK) */
++enum {
++	OP_RRQ = 1,
++	OP_WRQ,
++	OP_DATA,
++	OP_ACK,
++	OP_ERROR,
++	OP_OACK,
++};
++
++/* TFTP error codes (RFC 1350) plus the tqftpserv end-of-transfer sentinel */
++enum tftp_error {
++	TFTP_ERROR_UNDEF	= 0,
++	TFTP_ERROR_ENOENT	= 1,
++	TFTP_ERROR_EACCESS	= 2,
++	TFTP_ERROR_ENOSPACE	= 3,
++	TFTP_ERROR_EBADOP	= 4,
++	TFTP_ERROR_EBADID	= 5,
++	TFTP_ERROR_EEXISTS	= 6,
++	TFTP_ERROR_ENOUSER	= 7,
++	TFTP_ERROR_EOPTNEG	= 8,
++	ERROR_END_OF_TRANSFER	= 9,
++};
++
++/* RFC 2348 blksize range */
++#define MIN_BLKSIZE	8
++#define MAX_BLKSIZE	65464
++/* RFC 7440 windowsize range */
++#define MIN_WSIZE	1
++#define MAX_WSIZE	65535
++#define MAX_RSIZE	(100 * 1024 * 1024)
++#define MIN_TIMEOUTMS	1
++#define MAX_TIMEOUTMS	255000
++#define MIN_SEEK	0
++
++/* Path prefixes that map into the kernel firmware search path */
++static const char * const readonly_prefixes[] = {
++	"/readonly/vendor/firmware/",
++	"/readonly/firmware/image/",
++	"/readonly/vendor/firmware_mnt/image/",
++};
++#define READWRITE_PREFIX	"/readwrite/"
++
++/* Candidate directory prefixes for request_firmware(), in priority order.
++ * The first two match the built-in EXTRA_FIRMWARE blobs; the bare name
++ * covers a filesystem fallback under /lib/firmware.
++ */
++static const char * const fw_dir_prefixes[] = {
++	"ath10k/WCN3990/hw1.0/",
++	"qcom/sdm845/",
++	"",
++};
++
++struct tftp_client {
++	struct list_head node;
++
++	struct socket *sock;
++	struct sockaddr_qrtr sq;	/* peer address */
++
++	const struct firmware *fw;
++
++	size_t blksize;
++	size_t rsize;
++	size_t wsize;
++	unsigned int timeoutms;
++	loff_t seek;
++
++	u8 *blk_buf;		/* blksize + 4 header bytes */
++};
++
++static struct task_struct *tqftp_thread;
++static struct socket *tqftp_ctrl_sock;
++static struct sockaddr_qrtr tqftp_local;	/* our own node/port */
++static LIST_HEAD(readers);
++
++/* Woken by sk_data_ready on any of our sockets */
++static DECLARE_WAIT_QUEUE_HEAD(tqftp_waitq);
++static atomic_t tqftp_wake = ATOMIC_INIT(0);
++
++static void tqftp_data_ready(struct sock *sk)
++{
++	atomic_set(&tqftp_wake, 1);
++	wake_up_interruptible(&tqftp_waitq);
++}
++
++/* ---- low level QRTR socket helpers ---- */
++
++static int tqftp_sendto(struct socket *sock, const void *buf, size_t len,
++			const struct sockaddr_qrtr *dst)
++{
++	struct msghdr msg = { };
++	struct kvec iv = { (void *)buf, len };
++
++	if (dst) {
++		msg.msg_name = (void *)dst;
++		msg.msg_namelen = sizeof(*dst);
++	}
++
++	return kernel_sendmsg(sock, &msg, &iv, 1, len);
++}
++
++static int tqftp_recvfrom(struct socket *sock, void *buf, size_t len,
++			  struct sockaddr_qrtr *src)
++{
++	struct msghdr msg = { };
++	struct kvec iv = { buf, len };
++
++	msg.msg_name = src;
++	msg.msg_namelen = sizeof(*src);
++
++	return kernel_recvmsg(sock, &msg, &iv, 1, len, MSG_DONTWAIT);
++}
++
++static struct socket *tqftp_open_sock(struct sockaddr_qrtr *local)
++{
++	struct socket *sock;
++	int ret;
++
++	ret = sock_create_kern(&init_net, AF_QIPCRTR, SOCK_DGRAM,
++			       PF_QIPCRTR, &sock);
++	if (ret < 0)
++		return ERR_PTR(ret);
++
++	if (local) {
++		ret = kernel_getsockname(sock, (struct sockaddr *)local);
++		if (ret < 0) {
++			sock_release(sock);
++			return ERR_PTR(ret);
++		}
++	}
++
++	sock->sk->sk_data_ready = tqftp_data_ready;
++	sock->sk->sk_error_report = tqftp_data_ready;
++
++	return sock;
++}
++
++/* ---- TFTP protocol ---- */
++
++static void tftp_send_error(struct socket *sock, const struct sockaddr_qrtr *dst,
++			    enum tftp_error code, const char *msg)
++{
++	size_t len = 4 + strlen(msg) + 1;
++	u8 *buf;
++
++	buf = kzalloc(len, GFP_KERNEL);
++	if (!buf)
++		return;
++
++	buf[0] = 0;
++	buf[1] = OP_ERROR;
++	buf[2] = (code >> 8) & 0xff;
++	buf[3] = code & 0xff;
++	memcpy(buf + 4, msg, len - 4);
++
++	tqftp_sendto(sock, buf, len, dst);
++	kfree(buf);
++}
++
++/* Send TFTP ERROR to a peer we don't have a session for yet. */
++static void tftp_send_error_to(const struct sockaddr_qrtr *sq,
++			       enum tftp_error code, const char *msg)
++{
++	struct socket *sock;
++
++	sock = tqftp_open_sock(NULL);
++	if (IS_ERR(sock))
++		return;
++
++	tftp_send_error(sock, sq, code, msg);
++	sock_release(sock);
++}
++
++/*
++ * tftp_send_data() - send one DATA block to the client.
++ * @block: 1-based TFTP block number
++ * @offset: byte offset into the firmware image (already includes seek)
++ * @response_size: if non-zero, cap the payload to this many bytes (rsize path)
++ *
++ * Returns the number of payload bytes placed in the packet (0..blksize) on
++ * success, or negative on error.
++ */
++static int tftp_send_data(struct tftp_client *client, unsigned int block,
++			  size_t offset, size_t response_size)
++{
++	u8 *buf = client->blk_buf;
++	u8 *p = buf;
++	size_t avail;
++	size_t payload;
++	int ret;
++
++	*p++ = 0;
++	*p++ = OP_DATA;
++	*p++ = (block >> 8) & 0xff;
++	*p++ = block & 0xff;
++
++	if (offset >= client->fw->size)
++		avail = 0;
++	else
++		avail = client->fw->size - offset;
++
++	payload = min(avail, client->blksize);
++
++	if (response_size != 0) {
++		if (response_size > payload) {
++			pr_err("requested %zu bytes but only %zu available, rejecting\n",
++			       response_size, payload);
++			return -EINVAL;
++		}
++		payload = response_size;
++	}
++
++	if (payload)
++		memcpy(p, client->fw->data + offset, payload);
++	p += payload;
++
++	ret = tqftp_sendto(client->sock, buf, p - buf, &client->sq);
++	if (ret < 0)
++		return ret;
++
++	pr_debug("sent block %u (%zu bytes) to %d:%d\n",
++		 block, payload, client->sq.sq_node, client->sq.sq_port);
++	return payload;
++}
++
++static int tftp_send_oack(struct socket *sock, const struct sockaddr_qrtr *dst,
++			  const size_t *blksize, const ssize_t *tsize,
++			  const size_t *wsize, const unsigned int *timeoutms,
++			  const size_t *rsize, const loff_t *seek)
++{
++	char buf[512];
++	char *end = buf + sizeof(buf);
++	char *p = buf;
++	int n;
++
++	*p++ = 0;
++	*p++ = OP_OACK;
++
++#define APPEND_OPT(name, fmt, val)					\
++	do {								\
++		size_t nlen = sizeof(name);				\
++		if (p + nlen >= end)					\
++			return -EINVAL;					\
++		memcpy(p, name, nlen);					\
++		p += nlen;						\
++		n = scnprintf(p, end - p, fmt, val);			\
++		p += n + 1;	/* include the NUL scnprintf wrote */	\
++	} while (0)
++
++	if (blksize)
++		APPEND_OPT("blksize", "%zu", *blksize);
++	if (timeoutms)
++		APPEND_OPT("timeoutms", "%u", *timeoutms);
++	if (tsize && *tsize != -1)
++		APPEND_OPT("tsize", "%zd", *tsize);
++	if (wsize)
++		APPEND_OPT("wsize", "%zu", *wsize);
++	if (rsize)
++		APPEND_OPT("rsize", "%zu", *rsize);
++	if (seek)
++		APPEND_OPT("seek", "%lld", (long long)*seek);
++#undef APPEND_OPT
++
++	return tqftp_sendto(sock, buf, p - buf, dst);
++}
++
++/*
++ * parse_options() - parse the option list trailing an RRQ.
++ * Mirrors andersson/tqftpserv parse_options(): NUL-separated opt/value pairs.
++ */
++static int parse_options(const char *buf, size_t len, size_t *blksize,
++			 ssize_t *tsize, size_t *wsize, unsigned int *timeoutms,
++			 size_t *rsize, loff_t *seek)
++{
++	const char *end = buf + len;
++	const char *p = buf;
++	const char *opt, *value;
++	size_t opt_len, value_len;
++	long long val;
++
++	while (p < end) {
++		opt = p;
++		opt_len = strnlen(opt, end - p);
++		if (opt_len == (size_t)(end - p))
++			return -1;
++		p += opt_len + 1;
++
++		if (p >= end)
++			return -1;
++
++		value = p;
++		value_len = strnlen(value, end - p);
++		if (value_len == (size_t)(end - p))
++			return -1;
++		p += value_len + 1;
++
++		if (kstrtoll(value, 10, &val))
++			continue;
++
++		if (!strcmp(opt, "blksize")) {
++			if (val < MIN_BLKSIZE || val > MAX_BLKSIZE)
++				return -1;
++			*blksize = val;
++		} else if (!strcmp(opt, "timeoutms")) {
++			if (val < MIN_TIMEOUTMS || val > MAX_TIMEOUTMS)
++				return -1;
++			*timeoutms = val;
++		} else if (!strcmp(opt, "tsize")) {
++			if (val < 0)
++				return -1;
++			*tsize = val;
++		} else if (!strcmp(opt, "rsize")) {
++			if (val < 1 || val > MAX_RSIZE)
++				return -1;
++			*rsize = val;
++		} else if (!strcmp(opt, "wsize")) {
++			if (val < MIN_WSIZE || val > MAX_WSIZE)
++				return -1;
++			*wsize = val;
++		} else if (!strcmp(opt, "seek")) {
++			if (val < MIN_SEEK)
++				return -1;
++			*seek = val;
++		} else {
++			pr_debug("ignoring unknown option '%s'='%s'\n", opt, value);
++		}
++	}
++
++	return 0;
++}
++
++/*
++ * translate_path() - map a virtual TFTP path to a firmware image.
++ *
++ * Strips a known readonly prefix, rejects path traversal, then tries
++ * request_firmware() with each candidate directory prefix in order. On
++ * success stores the firmware in *out_fw. Returns 0 on success.
++ */
++static int translate_path(const char *path, const struct firmware **out_fw)
++{
++	const char *rel = NULL;
++	char name[256];
++	int i;
++
++	if (!strncmp(path, READWRITE_PREFIX, strlen(READWRITE_PREFIX))) {
++		pr_info("write path '%s' rejected (read-only server)\n", path);
++		return -EACCES;
++	}
++
++	for (i = 0; i < ARRAY_SIZE(readonly_prefixes); i++) {
++		size_t plen = strlen(readonly_prefixes[i]);
++
++		if (!strncmp(path, readonly_prefixes[i], plen)) {
++			rel = path + plen;
++			break;
++		}
++	}
++
++	if (!rel) {
++		pr_info("path '%s' has no known prefix, rejecting\n", path);
++		return -ENOENT;
++	}
++
++	if (strstr(rel, "..")) {
++		pr_info("path traversal in '%s' rejected\n", path);
++		return -EACCES;
++	}
++
++	for (i = 0; i < ARRAY_SIZE(fw_dir_prefixes); i++) {
++		int ret;
++
++		if (snprintf(name, sizeof(name), "%s%s",
++			     fw_dir_prefixes[i], rel) >= sizeof(name))
++			continue;
++
++		ret = request_firmware(out_fw, name, NULL);
++		if (!ret) {
++			pr_info("serving '%s' as '%s' (%zu bytes)\n",
++				path, name, (*out_fw)->size);
++			return 0;
++		}
++	}
++
++	pr_info("no firmware found for '%s' (rel '%s')\n", path, rel);
++	return -ENOENT;
++}
++
++static void client_free(struct tftp_client *client)
++{
++	list_del(&client->node);
++	if (client->fw)
++		release_firmware(client->fw);
++	if (client->sock)
++		sock_release(client->sock);
++	kfree(client->blk_buf);
++	kfree(client);
++}
++
++static void handle_rrq(const char *buf, size_t len, const struct sockaddr_qrtr *sq)
++{
++	struct tftp_client *client;
++	const char *end = buf + len;
++	const char *p = buf + 2;
++	const char *filename, *mode;
++	size_t filename_len, mode_len;
++	ssize_t tsize = -1;
++	size_t blksize = 512;
++	unsigned int timeoutms = 1000;
++	size_t rsize = 0;
++	size_t wsize = 1;
++	loff_t seek = 0;
++	bool do_oack = false;
++	struct socket *sock;
++	const struct firmware *fw = NULL;
++	int ret;
++
++	filename = p;
++	filename_len = strnlen(filename, end - p);
++	if (filename_len == (size_t)(end - p)) {
++		pr_err("RRQ: filename not NUL-terminated\n");
++		return;
++	}
++	p += filename_len + 1;
++
++	if (p >= end) {
++		pr_err("RRQ: missing mode\n");
++		return;
++	}
++	mode = p;
++	mode_len = strnlen(mode, end - p);
++	if (mode_len == (size_t)(end - p)) {
++		pr_err("RRQ: mode not NUL-terminated\n");
++		return;
++	}
++	p += mode_len + 1;
++
++	if (strcasecmp(mode, "octet")) {
++		pr_err("RRQ: unsupported mode '%s'\n", mode);
++		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
++		return;
++	}
++
++	pr_info("RRQ '%s' (mode %s) from %d:%d\n",
++		filename, mode, sq->sq_node, sq->sq_port);
++
++	if (p < end) {
++		do_oack = true;
++		ret = parse_options(p, end - p, &blksize, &tsize, &wsize,
++				    &timeoutms, &rsize, &seek);
++		if (ret < 0) {
++			pr_err("RRQ: bad options, rejecting\n");
++			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG,
++					   "Option negotiation failed");
++			return;
++		}
++	}
++
++	ret = translate_path(filename, &fw);
++	if (ret < 0) {
++		tftp_send_error_to(sq, TFTP_ERROR_ENOENT, "file not found");
++		return;
++	}
++
++	if (tsize != -1)
++		tsize = fw->size;
++
++	sock = tqftp_open_sock(NULL);
++	if (IS_ERR(sock)) {
++		release_firmware(fw);
++		return;
++	}
++
++	client = kzalloc(sizeof(*client), GFP_KERNEL);
++	if (!client) {
++		sock_release(sock);
++		release_firmware(fw);
++		return;
++	}
++
++	client->blk_buf = kzalloc(blksize + 4, GFP_KERNEL);
++	if (!client->blk_buf) {
++		kfree(client);
++		sock_release(sock);
++		release_firmware(fw);
++		return;
++	}
++
++	client->sock = sock;
++	client->sq = *sq;
++	client->fw = fw;
++	client->blksize = blksize;
++	client->rsize = rsize;
++	client->wsize = wsize;
++	client->timeoutms = timeoutms;
++	client->seek = seek;
++
++	pr_info("'%s' opened (blksize=%zu wsize=%zu rsize=%zu seek=%lld)\n",
++		filename, blksize, wsize, rsize, (long long)seek);
++
++	list_add(&client->node, &readers);
++
++	if (do_oack) {
++		/*
++		 * Options were negotiated: reply with OACK. The client then
++		 * ACKs block 0, driving the windowed transfer in handle_reader.
++		 */
++		tftp_send_oack(sock, sq, &blksize,
++			       tsize ? &tsize : NULL,
++			       wsize ? &wsize : NULL,
++			       &client->timeoutms,
++			       rsize ? &rsize : NULL,
++			       seek ? &seek : NULL);
++	} else {
++		/* No options: start streaming immediately with block 1. */
++		tftp_send_data(client, 1, 0, 0);
++	}
++}
++
++/*
++ * handle_reader() - process one ACK from a client and send the next window.
++ *
++ * Mirrors andersson/tqftpserv handle_reader() exactly. On an ACK for block
++ * @last we send blocks [last+1 .. last+wsize], each optionally capped by
++ * rsize. seek shifts the file offset. Returns:
++ *   <= 0 : transfer complete or failed, caller frees the client
++ *   > 0  : window sent, keep the client alive
++ */
++static int handle_reader(struct tftp_client *client)
++{
++	struct sockaddr_qrtr sq;
++	u8 buf[128];
++	u16 last;
++	unsigned int block;
++	int opcode;
++	int len;
++	int n = 0;
++
++	len = tqftp_recvfrom(client->sock, buf, sizeof(buf), &sq);
++	if (len < 0)
++		return -1;
++
++	/* Drop unsolicited/spoofed messages */
++	if (sq.sq_node != client->sq.sq_node ||
++	    sq.sq_port != client->sq.sq_port) {
++		pr_debug("discarding spoofed message\n");
++		return -1;
++	}
++
++	if (len < 4)
++		return -1;
++
++	opcode = buf[0] << 8 | buf[1];
++	if (opcode == OP_ERROR) {
++		int err = buf[2] << 8 | buf[3];
++
++		if (err == ERROR_END_OF_TRANSFER)
++			pr_info("end of transfer from %d:%d\n",
++				sq.sq_node, sq.sq_port);
++		else
++			pr_err("remote error %d from %d:%d\n",
++			       err, sq.sq_node, sq.sq_port);
++		return -1;
++	} else if (opcode != OP_ACK) {
++		pr_err("expected ACK, got %d\n", opcode);
++		tftp_send_error(client->sock, &client->sq,
++				TFTP_ERROR_EBADOP, "Expected ACK opcode");
++		return -1;
++	}
++
++	last = buf[2] << 8 | buf[3];
++	pr_debug("got ack %u from %d:%d\n", last, sq.sq_node, sq.sq_port);
++
++	/* We've already sent enough data for rsize */
++	if (client->rsize && last * client->blksize > client->rsize)
++		return 0;
++
++	for (block = last; block < last + client->wsize; block++) {
++		size_t offset = client->seek + (size_t)block * client->blksize;
++		size_t response_size = 0;
++
++		if (client->rsize &&
++		    (block + 1) * client->blksize > client->rsize)
++			response_size = client->rsize % client->blksize;
++
++		n = tftp_send_data(client, block + 1, offset, response_size);
++		if (n < 0) {
++			pr_err("send block %u failed: %d\n", block + 1, n);
++			break;
++		}
++		if (n == 0)	/* short/empty block: end of file */
++			break;
++
++		if (client->rsize &&
++		    (block + 1) * client->blksize > client->rsize)
++			break;
++	}
++
++	return 1;
++}
++
++/* Decode a QRTR control packet on the control socket (only BYE matters). */
++static void handle_ctrl(const void *buf, size_t len, const struct sockaddr_qrtr *sq)
++{
++	const struct qrtr_ctrl_pkt *pkt = buf;
++	struct tftp_client *client, *next;
++	u32 cmd;
++
++	if (len < sizeof(*pkt))
++		return;
++
++	cmd = le32_to_cpu(pkt->cmd);
++	if (cmd == QRTR_TYPE_BYE) {
++		list_for_each_entry_safe(client, next, &readers, node) {
++			if (client->sq.sq_node == sq->sq_node)
++				client_free(client);
++		}
++	} else if (cmd == QRTR_TYPE_DEL_CLIENT) {
++		u32 node = le32_to_cpu(pkt->client.node);
++		u32 port = le32_to_cpu(pkt->client.port);
++
++		list_for_each_entry_safe(client, next, &readers, node) {
++			if (client->sq.sq_node == node &&
++			    client->sq.sq_port == port)
++				client_free(client);
++		}
++	}
++}
++
++/* Drain the control socket: RRQ/WRQ requests and QRTR control messages. */
++static void service_ctrl_sock(void)
++{
++	static u8 buf[4096];
++	struct sockaddr_qrtr sq;
++	int opcode;
++	int len;
++
++	while ((len = tqftp_recvfrom(tqftp_ctrl_sock, buf, sizeof(buf), &sq)) >= 0) {
++		if (sq.sq_port == QRTR_PORT_CTRL) {
++			handle_ctrl(buf, len, &sq);
++			continue;
++		}
++
++		if (len < 2)
++			continue;
++
++		opcode = buf[0] << 8 | buf[1];
++		switch (opcode) {
++		case OP_RRQ:
++			handle_rrq(buf, len, &sq);
++			break;
++		case OP_WRQ:
++			pr_info("WRQ from %d:%d rejected (read-only server)\n",
++				sq.sq_node, sq.sq_port);
++			tftp_send_error_to(&sq, TFTP_ERROR_EACCESS,
++					   "Write not supported");
++			break;
++		case OP_ERROR:
++			pr_err("error %d from %d:%d\n",
++			       buf[2] << 8 | buf[3], sq.sq_node, sq.sq_port);
++			break;
++		default:
++			pr_err("unhandled op %d from %d:%d\n",
++			       opcode, sq.sq_node, sq.sq_port);
++			break;
++		}
++	}
++}
++
++/* Register QRTR service 4096 by sending a NEW_SERVER control packet. */
++static int tqftp_publish(void)
++{
++	struct qrtr_ctrl_pkt pkt = { };
++	struct sockaddr_qrtr sq;
++
++	pkt.cmd = cpu_to_le32(QRTR_TYPE_NEW_SERVER);
++	pkt.server.service = cpu_to_le32(TQFTP_SERVICE);
++	/* Encoding matches qmi_send_new_server(): version | instance << 8 */
++	pkt.server.instance = cpu_to_le32(TQFTP_VERSION | TQFTP_INSTANCE << 8);
++	pkt.server.node = cpu_to_le32(tqftp_local.sq_node);
++	pkt.server.port = cpu_to_le32(tqftp_local.sq_port);
++
++	sq.sq_family = tqftp_local.sq_family;
++	sq.sq_node = tqftp_local.sq_node;
++	sq.sq_port = QRTR_PORT_CTRL;
++
++	return tqftp_sendto(tqftp_ctrl_sock, &pkt, sizeof(pkt), &sq);
++}
++
++static int tqftp_kthread(void *data)
++{
++	struct tftp_client *client, *next;
++	int ret;
++
++	/*
++	 * Open the control socket in the kthread context. qrtr may still be
++	 * coming up during boot, so retry the whole open+publish sequence
++	 * until it succeeds (the modem retries its TFTP fetch anyway, but we
++	 * want to be registered as early as possible).
++	 */
++	while (!kthread_should_stop()) {
++		tqftp_ctrl_sock = tqftp_open_sock(&tqftp_local);
++		if (!IS_ERR(tqftp_ctrl_sock)) {
++			ret = tqftp_publish();
++			if (ret >= 0)
++				break;
++			pr_warn("service publish failed (%d), retrying\n", ret);
++			sock_release(tqftp_ctrl_sock);
++			tqftp_ctrl_sock = NULL;
++		}
++		schedule_timeout_interruptible(HZ);
++	}
++
++	if (kthread_should_stop())
++		return 0;
++
++	pr_info("published TFTP service %d (node %d port %d)\n",
++		TQFTP_SERVICE, tqftp_local.sq_node, tqftp_local.sq_port);
++
++	while (!kthread_should_stop()) {
++		wait_event_interruptible(tqftp_waitq,
++					 atomic_xchg(&tqftp_wake, 0) ||
++					 kthread_should_stop());
++		if (kthread_should_stop())
++			break;
++
++		/*
++		 * A single sk_data_ready fires for whichever socket got data;
++		 * we don't know which, so drain them all (mirrors the userspace
++		 * select() loop servicing every ready fd).
++		 */
++		list_for_each_entry_safe(client, next, &readers, node) {
++			ret = handle_reader(client);
++			if (ret <= 0)
++				client_free(client);
++		}
++
++		service_ctrl_sock();
++	}
++
++	list_for_each_entry_safe(client, next, &readers, node)
++		client_free(client);
++
++	return 0;
++}
++
++static int __init tqftp_init(void)
++{
++	tqftp_thread = kthread_run(tqftp_kthread, NULL, "tqftpserv");
++	if (IS_ERR(tqftp_thread)) {
++		pr_err("failed to start kthread: %ld\n", PTR_ERR(tqftp_thread));
++		return PTR_ERR(tqftp_thread);
++	}
++	return 0;
++}
++
++static void __exit tqftp_exit(void)
++{
++	if (tqftp_thread)
++		kthread_stop(tqftp_thread);
++	if (tqftp_ctrl_sock && !IS_ERR(tqftp_ctrl_sock))
++		sock_release(tqftp_ctrl_sock);
++}
++
++/* late_initcall: run after qrtr (subsys/module init) is up. */
++late_initcall(tqftp_init);
++module_exit(tqftp_exit);
++
++MODULE_DESCRIPTION("In-kernel TFTP-over-QRTR server for Qualcomm peripheral firmware");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0
+

--- a/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
+++ b/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
@@ -1,0 +1,1225 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trey Moen <trey@moen.ai>
+Date: Wed, 1 Jul 2026 00:00:02 +0000
+Subject: soc: qcom: add in-kernel remote filesystem (rmtfs) QMI service
+
+Minimal in-kernel reimplementation of the userspace linux-msm/rmtfs daemon.
+Publishes QMI service 14 (rmtfs, version 1, instance 0) and services the
+modem's EFS read/write requests, which the modem remoteproc requires: without
+it the modem boots but self-fatals after ~40s because rmtfs is unavailable.
+Required on comma devices where the proprietary Qualcomm userspace is inert.
+
+EFS lives in the modemst1/modemst2/fsc/fsg GPT partitions (factory
+calibration/provisioning). To eliminate any risk of corrupting that data,
+on-flash EFS is treated as strictly read-only: each backing partition is
+shadowed in RAM on first access, reads are served from the shadow, and writes
+are applied only to the shadow (never written back to flash). This mirrors the
+userspace daemon's read-only shadow mode, which is how vamOS runs it
+(rmtfs -r -s -P). Partitions are resolved by GPT partlabel entirely in-kernel
+(matching bd_meta_info->volname across block_class), so no udev by-partlabel
+symlinks are needed. RW_IOVEC payload moves through the reserved qcom,rmtfs-mem
+region, which the existing qcom_rmtfs_mem driver still SCM-assigns to the
+modem; this service only additionally memremaps it.
+
+---
+diff --git a/drivers/soc/qcom/Kconfig b/drivers/soc/qcom/Kconfig
+index 0922d0cb5..fe616cbad 100644
+--- a/drivers/soc/qcom/Kconfig
++++ b/drivers/soc/qcom/Kconfig
+@@ -107,6 +107,20 @@ config QCOM_TQFTPSERV
+ 	  protection domain on systems where the proprietary Qualcomm userspace
+ 	  is not present. Read-only; writes are rejected.
+ 
++config QCOM_RMTFS_SERV
++	tristate "Qualcomm in-kernel remote filesystem (rmtfs) QMI service"
++	depends on NET && QRTR && BLOCK
++	select QCOM_QMI_HELPERS
++	help
++	  In-kernel reimplementation of the userspace linux-msm/rmtfs daemon.
++	  It publishes QMI service 14 (rmtfs) and services the modem's EFS
++	  read/write requests out of the modemst1/modemst2/fsc/fsg partitions,
++	  moving payload through the reserved qcom,rmtfs-mem region. This is
++	  needed to keep the modem remoteproc alive on systems where the
++	  proprietary Qualcomm userspace is not present. On-flash EFS is treated
++	  as read-only: partitions are shadowed in RAM and writes are applied
++	  only to the RAM copy, never written back to flash.
++
+ config QCOM_PMIC_PDCHARGER_ULOG
+ 	tristate "Qualcomm PMIC PDCharger ULOG driver"
+ 	depends on RPMSG
+diff --git a/drivers/soc/qcom/Makefile b/drivers/soc/qcom/Makefile
+index 7903de1ee..de19d30e9 100644
+--- a/drivers/soc/qcom/Makefile
++++ b/drivers/soc/qcom/Makefile
+@@ -11,6 +11,7 @@ obj-$(CONFIG_QCOM_PD_MAPPER)	+= qcom_pd_mapper.o
+ obj-$(CONFIG_QCOM_PDR_HELPERS)	+= pdr_interface.o
+ obj-$(CONFIG_QCOM_PDR_MSG)	+= qcom_pdr_msg.o
+ obj-$(CONFIG_QCOM_TQFTPSERV)	+= qcom_tqftpserv.o
++obj-$(CONFIG_QCOM_RMTFS_SERV)	+= qcom_rmtfs_serv.o
+ obj-$(CONFIG_QCOM_PMIC_GLINK)	+= pmic_glink.o
+ obj-$(CONFIG_QCOM_PMIC_GLINK)	+= pmic_glink_altmode.o
+ obj-$(CONFIG_QCOM_PMIC_PDCHARGER_ULOG)	+= pmic_pdcharger_ulog.o
+diff --git a/drivers/soc/qcom/qcom_rmtfs_serv.c b/drivers/soc/qcom/qcom_rmtfs_serv.c
+new file mode 100644
+index 000000000..e82330b3d
+--- /dev/null
++++ b/drivers/soc/qcom/qcom_rmtfs_serv.c
+@@ -0,0 +1,1156 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * In-kernel Qualcomm remote filesystem (rmtfs) QMI service.
++ *
++ * On an unmodified legacy comma rootfs the proprietary Qualcomm userspace
++ * daemons are inert, so nothing answers the RMTFS QMI requests the modem
++ * issues to access its EFS storage. The modem remoteproc boots but self-fatals
++ * after ~40s because QMI service 14 (rmtfs) is unavailable. This is a minimal,
++ * in-kernel reimplementation of the userspace linux-msm/rmtfs daemon that
++ * publishes QMI service 14 (version 1, instance 0) and services the modem's
++ * EFS read/write requests.
++ *
++ * Storage safety model (deliberate):
++ *   The modem's EFS lives in the modemst1/modemst2/fsc/fsg GPT partitions,
++ *   which hold factory calibration and provisioning data. To eliminate any
++ *   risk of corrupting that data we treat on-flash EFS as strictly READ-ONLY:
++ *   on first access each backing partition is copied in full into a RAM shadow
++ *   buffer; reads are served from the shadow, and writes are applied ONLY to
++ *   the shadow (never written back to flash). This keeps the modem happy
++ *   (its writes "succeed") with zero risk to the factory partitions. This
++ *   mirrors the userspace daemon's -r (read-only) shadow-buffer behaviour,
++ *   which is how vamOS runs it (rmtfs -r -s -P).
++ *
++ * The bulk EFS payload for RW_IOVEC transfers moves through the reserved rmtfs
++ * shared-memory region (DT compatible "qcom,rmtfs-mem"), which the existing
++ * qcom_rmtfs_mem driver has already SCM-assigned to the modem. We additionally
++ * memremap the same region here to move sectors between it and the RAM shadow.
++ *
++ * Protocol reference: linux-msm/rmtfs (github.com/linux-msm/rmtfs).
++ * Copyright (c) 2016-2018, Linaro Ltd. (protocol reference)
++ */
++
++#define pr_fmt(fmt) "rmtfs: " fmt
++
++#include <linux/blkdev.h>
++#include <linux/fs.h>
++#include <linux/io.h>
++#include <linux/kernel.h>
++#include <linux/kthread.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/of.h>
++#include <linux/of_reserved_mem.h>
++#include <linux/sizes.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <linux/vmalloc.h>
++
++#include <linux/soc/qcom/qmi.h>
++
++/* QMI service identity: RMTFS, version 1, instance 0 */
++#define RMTFS_SERVICE			14
++#define RMTFS_VERSION			1
++#define RMTFS_INSTANCE			0
++
++/* QMI message ids (from linux-msm/rmtfs qmi_rmtfs.h) */
++#define QMI_RMTFS_OPEN			0x01
++#define QMI_RMTFS_CLOSE			0x02
++#define QMI_RMTFS_RW_IOVEC		0x03
++#define QMI_RMTFS_ALLOC_BUFF		0x04
++#define QMI_RMTFS_GET_DEV_ERROR		0x05
++/* 0x06 FORCE_SYNC is an indication we send to the modem; unused here */
++
++/* rmtfs-specific result/error codes */
++#define QMI_RMTFS_ERR_NONE		0
++#define QMI_RMTFS_ERR_INTERNAL		1
++
++/* EFS is addressed in 512-byte sectors (linux-msm/rmtfs SECTOR_SIZE) */
++#define RMTFS_SECTOR_SIZE		512
++
++/* Max simultaneous callers, mirrors linux-msm/rmtfs MAX_CALLERS */
++#define RMTFS_MAX_CALLERS		10
++
++/* Longest path the modem may request (rmtfs_open_req.path is char[256]) */
++#define RMTFS_MAX_PATH			256
++
++/* Refuse to shadow a partition larger than this (EFS partitions are small) */
++#define RMTFS_MAX_SHADOW		(16 * 1024 * 1024)
++
++/* Max iovec entries in one RW_IOVEC (rmtfs_iovec_req.iovec is [255]) */
++#define RMTFS_MAX_IOVEC			255
++
++/*
++ * Path -> GPT partlabel mapping. The modem opens the "/boot/modem_*" virtual
++ * paths; each maps to a raw EFS partition addressed by its GPT volume name.
++ * (linux-msm/rmtfs storage.c partition_table.)
++ */
++static const struct rmtfs_partition {
++	const char *path;
++	const char *partlabel;
++} rmtfs_partitions[] = {
++	{ "/boot/modem_fs1",		"modemst1" },
++	{ "/boot/modem_fs2",		"modemst2" },
++	{ "/boot/modem_fsc",		"fsc" },
++	{ "/boot/modem_fsg",		"fsg" },
++	{ "/boot/modem_study",		"study" },
++	{ "/boot/modem_tunning",	"tunning" },
++};
++
++/*
++ * One open EFS backing store. caller_id is the index of this slot in the
++ * rmtfds[] array (mirrors linux-msm/rmtfs, where caller_id == array index).
++ */
++struct rmtfs_caller {
++	bool in_use;
++	unsigned int id;		/* == index in rmtfds[] == caller_id */
++	unsigned int node;		/* QRTR node that opened us */
++	const struct rmtfs_partition *part;
++
++	/* RAM shadow of the backing partition (read-only w.r.t. flash) */
++	u8 *shadow;
++	size_t shadow_len;
++
++	u32 dev_error;
++};
++
++/* ---- QMI wire structures (decoded form) ---- */
++
++struct rmtfs_qmi_result {
++	u16 result;
++	u16 error;
++};
++
++struct rmtfs_iovec_entry {
++	u32 sector_addr;
++	u32 phys_offset;
++	u32 num_sector;
++};
++
++struct rmtfs_open_req {
++	char path[RMTFS_MAX_PATH];
++};
++
++struct rmtfs_open_resp {
++	struct rmtfs_qmi_result result;
++	u8 caller_id_valid;
++	u32 caller_id;
++};
++
++struct rmtfs_close_req {
++	u32 caller_id;
++};
++
++struct rmtfs_close_resp {
++	struct rmtfs_qmi_result result;
++};
++
++struct rmtfs_iovec_req {
++	u32 caller_id;
++	u8 direction;			/* 0 = read (mem<-storage), 1 = write */
++	u32 iovec_len;
++	struct rmtfs_iovec_entry iovec[RMTFS_MAX_IOVEC];
++	u8 is_force_sync;
++};
++
++struct rmtfs_iovec_resp {
++	struct rmtfs_qmi_result result;
++};
++
++struct rmtfs_alloc_buf_req {
++	u32 caller_id;
++	u32 buff_size;
++};
++
++struct rmtfs_alloc_buf_resp {
++	struct rmtfs_qmi_result result;
++	u8 buff_address_valid;
++	u64 buff_address;
++};
++
++struct rmtfs_dev_error_req {
++	u32 caller_id;
++};
++
++struct rmtfs_dev_error_resp {
++	struct rmtfs_qmi_result result;
++	u8 status_valid;
++	u8 status;
++};
++
++/* ---- QMI TLV descriptors (mirror linux-msm/rmtfs qmi_rmtfs.c) ---- */
++
++static const struct qmi_elem_info rmtfs_qmi_result_ei[] = {
++	{
++		.data_type	= QMI_UNSIGNED_2_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u16),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0,
++		.offset		= offsetof(struct rmtfs_qmi_result, result),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_2_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u16),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0,
++		.offset		= offsetof(struct rmtfs_qmi_result, error),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_iovec_entry_ei[] = {
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0,
++		.offset		= offsetof(struct rmtfs_iovec_entry, sector_addr),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0,
++		.offset		= offsetof(struct rmtfs_iovec_entry, phys_offset),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0,
++		.offset		= offsetof(struct rmtfs_iovec_entry, num_sector),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_open_req_ei[] = {
++	{
++		.data_type	= QMI_STRING,
++		.elem_len	= RMTFS_MAX_PATH,
++		.elem_size	= sizeof(char),
++		.array_type	= VAR_LEN_ARRAY,
++		.tlv_type	= 0x01,
++		.offset		= offsetof(struct rmtfs_open_req, path),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_open_resp_ei[] = {
++	{
++		.data_type	= QMI_STRUCT,
++		.elem_len	= 1,
++		.elem_size	= sizeof(struct rmtfs_qmi_result),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_open_resp, result),
++		.ei_array	= rmtfs_qmi_result_ei,
++	},
++	{
++		.data_type	= QMI_OPT_FLAG,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u8),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x10,
++		.offset		= offsetof(struct rmtfs_open_resp, caller_id_valid),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x10,
++		.offset		= offsetof(struct rmtfs_open_resp, caller_id),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_close_req_ei[] = {
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x01,
++		.offset		= offsetof(struct rmtfs_close_req, caller_id),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_close_resp_ei[] = {
++	{
++		.data_type	= QMI_STRUCT,
++		.elem_len	= 1,
++		.elem_size	= sizeof(struct rmtfs_qmi_result),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_close_resp, result),
++		.ei_array	= rmtfs_qmi_result_ei,
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_iovec_req_ei[] = {
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x01,
++		.offset		= offsetof(struct rmtfs_iovec_req, caller_id),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_1_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u8),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_iovec_req, direction),
++	},
++	{
++		.data_type	= QMI_DATA_LEN,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x03,
++		.offset		= offsetof(struct rmtfs_iovec_req, iovec_len),
++	},
++	{
++		.data_type	= QMI_STRUCT,
++		.elem_len	= RMTFS_MAX_IOVEC,
++		.elem_size	= sizeof(struct rmtfs_iovec_entry),
++		.array_type	= VAR_LEN_ARRAY,
++		.tlv_type	= 0x03,
++		.offset		= offsetof(struct rmtfs_iovec_req, iovec),
++		.ei_array	= rmtfs_iovec_entry_ei,
++	},
++	{
++		.data_type	= QMI_UNSIGNED_1_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u8),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x04,
++		.offset		= offsetof(struct rmtfs_iovec_req, is_force_sync),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_iovec_resp_ei[] = {
++	{
++		.data_type	= QMI_STRUCT,
++		.elem_len	= 1,
++		.elem_size	= sizeof(struct rmtfs_qmi_result),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_iovec_resp, result),
++		.ei_array	= rmtfs_qmi_result_ei,
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_alloc_buf_req_ei[] = {
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x01,
++		.offset		= offsetof(struct rmtfs_alloc_buf_req, caller_id),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_alloc_buf_req, buff_size),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_alloc_buf_resp_ei[] = {
++	{
++		.data_type	= QMI_STRUCT,
++		.elem_len	= 1,
++		.elem_size	= sizeof(struct rmtfs_qmi_result),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_alloc_buf_resp, result),
++		.ei_array	= rmtfs_qmi_result_ei,
++	},
++	{
++		.data_type	= QMI_OPT_FLAG,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u8),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x10,
++		.offset		= offsetof(struct rmtfs_alloc_buf_resp, buff_address_valid),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_8_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u64),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x10,
++		.offset		= offsetof(struct rmtfs_alloc_buf_resp, buff_address),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_dev_error_req_ei[] = {
++	{
++		.data_type	= QMI_UNSIGNED_4_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u32),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x01,
++		.offset		= offsetof(struct rmtfs_dev_error_req, caller_id),
++	},
++	{}
++};
++
++static const struct qmi_elem_info rmtfs_dev_error_resp_ei[] = {
++	{
++		.data_type	= QMI_STRUCT,
++		.elem_len	= 1,
++		.elem_size	= sizeof(struct rmtfs_qmi_result),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x02,
++		.offset		= offsetof(struct rmtfs_dev_error_resp, result),
++		.ei_array	= rmtfs_qmi_result_ei,
++	},
++	{
++		.data_type	= QMI_OPT_FLAG,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u8),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x10,
++		.offset		= offsetof(struct rmtfs_dev_error_resp, status_valid),
++	},
++	{
++		.data_type	= QMI_UNSIGNED_1_BYTE,
++		.elem_len	= 1,
++		.elem_size	= sizeof(u8),
++		.array_type	= NO_ARRAY,
++		.tlv_type	= 0x10,
++		.offset		= offsetof(struct rmtfs_dev_error_resp, status),
++	},
++	{}
++};
++
++/* ---- driver state ---- */
++
++static struct qmi_handle rmtfs_qmi;
++static bool rmtfs_qmi_ready;
++
++static DEFINE_MUTEX(rmtfs_lock);	/* guards rmtfds[] and shared-mem access */
++static struct rmtfs_caller rmtfds[RMTFS_MAX_CALLERS];
++
++/* memremap of the reserved "qcom,rmtfs-mem" region (shared with the modem) */
++static void __iomem *rmtfs_shmem;
++static phys_addr_t rmtfs_shmem_base;
++static size_t rmtfs_shmem_size;
++
++/* ---- reserved shared-memory region ---- */
++
++/*
++ * Map the reserved rmtfs shared-memory region. The modem transfers EFS payload
++ * through this region; RW_IOVEC phys_offset values are absolute physical
++ * addresses within it. We resolve and memremap it exactly the way the existing
++ * qcom_rmtfs_mem driver does (same base/size, same optional guard pages, same
++ * MEMREMAP_WC), so our view of a phys_offset matches the modem's. The
++ * qcom_rmtfs_mem driver still owns the SCM assignment; we only add a mapping.
++ */
++static int rmtfs_map_shmem(void)
++{
++	struct device_node *node;
++	struct reserved_mem *rmem;
++	phys_addr_t addr;
++	size_t size;
++
++	if (rmtfs_shmem)
++		return 0;
++
++	node = of_find_compatible_node(NULL, NULL, "qcom,rmtfs-mem");
++	if (!node) {
++		pr_err("no qcom,rmtfs-mem reserved-memory node in DT\n");
++		return -ENODEV;
++	}
++
++	rmem = of_reserved_mem_lookup(node);
++	if (!rmem) {
++		of_node_put(node);
++		pr_err("failed to look up rmtfs reserved memory\n");
++		return -EINVAL;
++	}
++
++	addr = rmem->base;
++	size = rmem->size;
++
++	/* Match qcom_rmtfs_mem's optional guard-page trimming. */
++	if (of_property_read_bool(node, "qcom,use-guard-pages")) {
++		addr += SZ_4K;
++		size -= 2 * SZ_4K;
++	}
++	of_node_put(node);
++
++	rmtfs_shmem = memremap(addr, size, MEMREMAP_WC);
++	if (!rmtfs_shmem) {
++		pr_err("failed to memremap rmtfs shmem %pa (%zu bytes)\n",
++		       &addr, size);
++		return -ENOMEM;
++	}
++
++	rmtfs_shmem_base = addr;
++	rmtfs_shmem_size = size;
++	pr_info("mapped rmtfs shmem: base %pa size %zu\n", &addr, size);
++	return 0;
++}
++
++/*
++ * Translate a modem phys_offset (absolute physical address within the shared
++ * region) to a kernel pointer, validating that [off, off+len) is in-bounds.
++ * Mirrors linux-msm/rmtfs: base + (phys - region_base).
++ */
++static void __iomem *rmtfs_shmem_ptr(u64 phys, size_t len)
++{
++	u64 rel;
++
++	if (phys < rmtfs_shmem_base)
++		return NULL;
++	rel = phys - rmtfs_shmem_base;
++	if (rel > rmtfs_shmem_size || len > rmtfs_shmem_size - rel)
++		return NULL;
++	return rmtfs_shmem + rel;
++}
++
++/* ---- partition -> RAM shadow ---- */
++
++static int rmtfs_match_partlabel(struct device *dev, const void *data)
++{
++	struct block_device *bdev = dev_to_bdev(dev);
++	const char *label = data;
++
++	if (!bdev->bd_meta_info || strcmp(label, bdev->bd_meta_info->volname))
++		return 0;
++	return 1;
++}
++
++/*
++ * Resolve a GPT partlabel to a dev_t entirely in-kernel by matching
++ * bd_meta_info->volname across block_class. This is the same mechanism the
++ * kernel's own PARTLABEL= root= parsing uses (block/early-lookup.c), so it
++ * needs no udev/by-partlabel symlinks in userspace.
++ */
++static int rmtfs_devt_from_partlabel(const char *label, dev_t *devt)
++{
++	struct device *dev;
++
++	dev = class_find_device(&block_class, NULL, label,
++				rmtfs_match_partlabel);
++	if (!dev)
++		return -ENODEV;
++	*devt = dev->devt;
++	put_device(dev);
++	return 0;
++}
++
++/*
++ * Read an EFS backing partition in full into a freshly allocated RAM shadow.
++ * The partition is opened READ-ONLY; we never write back to flash.
++ */
++static int rmtfs_load_shadow(const struct rmtfs_partition *part,
++			     u8 **out_buf, size_t *out_len)
++{
++	struct file *bdev_file;
++	dev_t devt;
++	loff_t size;
++	loff_t pos = 0;
++	u8 *buf;
++	int ret;
++
++	ret = rmtfs_devt_from_partlabel(part->partlabel, &devt);
++	if (ret) {
++		pr_err("partition '%s' not found (UFS not up yet?)\n",
++		       part->partlabel);
++		return ret;
++	}
++
++	bdev_file = bdev_file_open_by_dev(devt, BLK_OPEN_READ, &rmtfds, NULL);
++	if (IS_ERR(bdev_file)) {
++		ret = PTR_ERR(bdev_file);
++		pr_err("failed to open partition '%s': %d\n",
++		       part->partlabel, ret);
++		return ret;
++	}
++
++	size = bdev_nr_bytes(file_bdev(bdev_file));
++	if (size <= 0 || size > RMTFS_MAX_SHADOW) {
++		pr_err("partition '%s' has implausible size %lld, refusing\n",
++		       part->partlabel, size);
++		ret = -EFBIG;
++		goto out_close;
++	}
++
++	buf = vmalloc(size);
++	if (!buf) {
++		ret = -ENOMEM;
++		goto out_close;
++	}
++
++	while (pos < size) {
++		ssize_t n = kernel_read(bdev_file, buf + pos, size - pos, &pos);
++
++		if (n <= 0) {
++			pr_err("read of partition '%s' failed at %lld: %zd\n",
++			       part->partlabel, pos, n);
++			vfree(buf);
++			ret = n < 0 ? n : -EIO;
++			goto out_close;
++		}
++	}
++
++	*out_buf = buf;
++	*out_len = size;
++	ret = 0;
++	pr_info("loaded EFS shadow for '%s' (%s): %lld bytes (read-only)\n",
++		part->path, part->partlabel, size);
++
++out_close:
++	fput(bdev_file);
++	return ret;
++}
++
++/*
++ * Serve a sector read from the RAM shadow, zero-padding past EOF.
++ * Mirrors linux-msm/rmtfs storage_pread shadow behaviour.
++ */
++static void rmtfs_shadow_read(struct rmtfs_caller *c, u8 *dst, loff_t off,
++			      size_t len)
++{
++	size_t avail = 0;
++
++	if (off < c->shadow_len)
++		avail = min_t(size_t, len, c->shadow_len - off);
++	if (avail)
++		memcpy(dst, c->shadow + off, avail);
++	if (avail < len)
++		memset(dst + avail, 0, len - avail);
++}
++
++/*
++ * Apply a sector write to the RAM shadow ONLY (never to flash). Grows the
++ * shadow buffer if the modem writes past the current end, mirroring
++ * linux-msm/rmtfs storage_pwrite read-only shadow behaviour.
++ */
++static int rmtfs_shadow_write(struct rmtfs_caller *c, const u8 *src,
++			      loff_t off, size_t len)
++{
++	if (off < 0 || len > RMTFS_MAX_SHADOW || off > RMTFS_MAX_SHADOW - len)
++		return -EFBIG;
++
++	if (off + len > c->shadow_len) {
++		size_t newlen = off + len;
++		u8 *nb = vmalloc(newlen);
++
++		if (!nb)
++			return -ENOMEM;
++		if (c->shadow_len)
++			memcpy(nb, c->shadow, c->shadow_len);
++		memset(nb + c->shadow_len, 0, newlen - c->shadow_len);
++		vfree(c->shadow);
++		c->shadow = nb;
++		c->shadow_len = newlen;
++	}
++
++	memcpy(c->shadow + off, src, len);
++	return 0;
++}
++
++static void rmtfs_caller_release(struct rmtfs_caller *c)
++{
++	if (!c->in_use)
++		return;
++	vfree(c->shadow);
++	c->shadow = NULL;
++	c->shadow_len = 0;
++	c->in_use = false;
++	c->part = NULL;
++	c->node = 0;
++	c->dev_error = 0;
++}
++
++/* ---- QMI message handlers ---- */
++
++static void rmtfs_handle_open(struct qmi_handle *qmi, struct sockaddr_qrtr *sq,
++			      struct qmi_txn *txn, const void *decoded)
++{
++	const struct rmtfs_open_req *req = decoded;
++	struct rmtfs_open_resp resp = {};
++	const struct rmtfs_partition *part = NULL;
++	struct rmtfs_caller *c = NULL;
++	char path[RMTFS_MAX_PATH];
++	int i, ret;
++
++	strscpy(path, req->path, sizeof(path));
++	pr_info("OPEN '%s' from %d:%d\n", path, sq->sq_node, sq->sq_port);
++
++	for (i = 0; i < ARRAY_SIZE(rmtfs_partitions); i++) {
++		if (!strcmp(path, rmtfs_partitions[i].path)) {
++			part = &rmtfs_partitions[i];
++			break;
++		}
++	}
++	if (!part) {
++		pr_err("OPEN: unknown path '%s'\n", path);
++		resp.result.result = QMI_RESULT_FAILURE_V01;
++		resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++		goto respond;
++	}
++
++	mutex_lock(&rmtfs_lock);
++
++	/* Reuse an existing open for the same partition from the same node. */
++	for (i = 0; i < RMTFS_MAX_CALLERS; i++) {
++		if (rmtfds[i].in_use && rmtfds[i].part == part &&
++		    rmtfds[i].node == sq->sq_node) {
++			c = &rmtfds[i];
++			break;
++		}
++	}
++
++	if (!c) {
++		for (i = 0; i < RMTFS_MAX_CALLERS; i++) {
++			if (!rmtfds[i].in_use) {
++				c = &rmtfds[i];
++				break;
++			}
++		}
++		if (!c) {
++			mutex_unlock(&rmtfs_lock);
++			pr_err("OPEN: no free caller slots\n");
++			resp.result.result = QMI_RESULT_FAILURE_V01;
++			resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++			goto respond;
++		}
++
++		ret = rmtfs_load_shadow(part, &c->shadow, &c->shadow_len);
++		if (ret) {
++			mutex_unlock(&rmtfs_lock);
++			resp.result.result = QMI_RESULT_FAILURE_V01;
++			resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++			goto respond;
++		}
++
++		c->in_use = true;
++		c->id = i;
++		c->node = sq->sq_node;
++		c->part = part;
++		c->dev_error = 0;
++	}
++
++	resp.result.result = QMI_RESULT_SUCCESS_V01;
++	resp.result.error = QMI_RMTFS_ERR_NONE;
++	resp.caller_id_valid = 1;
++	resp.caller_id = c->id;
++	mutex_unlock(&rmtfs_lock);
++
++	pr_info("OPEN '%s' -> caller_id %u\n", path, resp.caller_id);
++
++respond:
++	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_OPEN,
++				sizeof(struct rmtfs_open_resp),
++				rmtfs_open_resp_ei, &resp);
++	if (ret < 0)
++		pr_err("OPEN: failed to send response: %d\n", ret);
++}
++
++static struct rmtfs_caller *rmtfs_find_caller(u32 caller_id, unsigned int node)
++{
++	struct rmtfs_caller *c;
++
++	if (caller_id >= RMTFS_MAX_CALLERS)
++		return NULL;
++	c = &rmtfds[caller_id];
++	if (!c->in_use || c->node != node)
++		return NULL;
++	return c;
++}
++
++static void rmtfs_handle_close(struct qmi_handle *qmi, struct sockaddr_qrtr *sq,
++			       struct qmi_txn *txn, const void *decoded)
++{
++	const struct rmtfs_close_req *req = decoded;
++	struct rmtfs_close_resp resp = {};
++	struct rmtfs_caller *c;
++	int ret;
++
++	mutex_lock(&rmtfs_lock);
++	c = rmtfs_find_caller(req->caller_id, sq->sq_node);
++	if (c) {
++		pr_info("CLOSE caller_id %u ('%s')\n",
++			req->caller_id, c->part->path);
++		rmtfs_caller_release(c);
++		resp.result.result = QMI_RESULT_SUCCESS_V01;
++		resp.result.error = QMI_RMTFS_ERR_NONE;
++	} else {
++		pr_err("CLOSE: bad caller_id %u\n", req->caller_id);
++		resp.result.result = QMI_RESULT_FAILURE_V01;
++		resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++	}
++	mutex_unlock(&rmtfs_lock);
++
++	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_CLOSE,
++				sizeof(struct rmtfs_close_resp),
++				rmtfs_close_resp_ei, &resp);
++	if (ret < 0)
++		pr_err("CLOSE: failed to send response: %d\n", ret);
++}
++
++/*
++ * RW_IOVEC: move EFS sectors between the shared-memory region and the RAM
++ * shadow. direction 0 = read (storage -> shmem), 1 = write (shmem -> storage,
++ * i.e. into the shadow only). Mirrors linux-msm/rmtfs rmtfs_iovec():
++ *   phys_base   = entry.phys_offset  (absolute phys addr in shmem)
++ *   sector_base = entry.sector_addr * SECTOR_SIZE  (byte offset in storage)
++ * transferring num_sector * SECTOR_SIZE bytes per entry.
++ */
++static void rmtfs_handle_iovec(struct qmi_handle *qmi, struct sockaddr_qrtr *sq,
++			       struct qmi_txn *txn, const void *decoded)
++{
++	const struct rmtfs_iovec_req *req = decoded;
++	struct rmtfs_iovec_resp resp = {};
++	struct rmtfs_caller *c;
++	bool is_write = req->direction;
++	u8 sector[RMTFS_SECTOR_SIZE];
++	unsigned int i, j;
++	bool logged = false;
++	int ret = 0;
++
++	mutex_lock(&rmtfs_lock);
++
++	c = rmtfs_find_caller(req->caller_id, sq->sq_node);
++	if (!c) {
++		pr_err("RW_IOVEC: bad caller_id %u\n", req->caller_id);
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (!rmtfs_shmem) {
++		pr_err("RW_IOVEC: shmem not mapped\n");
++		ret = -ENODEV;
++		goto out;
++	}
++
++	if (req->iovec_len > RMTFS_MAX_IOVEC) {
++		pr_err("RW_IOVEC: iovec_len %u too large\n", req->iovec_len);
++		ret = -EINVAL;
++		goto out;
++	}
++
++	for (i = 0; i < req->iovec_len; i++) {
++		const struct rmtfs_iovec_entry *e = &req->iovec[i];
++		u64 phys_base = e->phys_offset;
++		loff_t sector_base = (loff_t)e->sector_addr * RMTFS_SECTOR_SIZE;
++		loff_t off = 0;
++
++		for (j = 0; j < e->num_sector; j++) {
++			void __iomem *mem;
++
++			mem = rmtfs_shmem_ptr(phys_base + off, RMTFS_SECTOR_SIZE);
++			if (!mem) {
++				pr_err("RW_IOVEC: phys 0x%llx out of shmem\n",
++				       phys_base + off);
++				ret = -EINVAL;
++				goto out;
++			}
++
++			if (is_write) {
++				memcpy_fromio(sector, mem, RMTFS_SECTOR_SIZE);
++				ret = rmtfs_shadow_write(c, sector,
++							 sector_base + off,
++							 RMTFS_SECTOR_SIZE);
++				if (ret) {
++					pr_err("RW_IOVEC: shadow write failed: %d\n",
++					       ret);
++					goto out;
++				}
++			} else {
++				rmtfs_shadow_read(c, sector, sector_base + off,
++						  RMTFS_SECTOR_SIZE);
++				memcpy_toio(mem, sector, RMTFS_SECTOR_SIZE);
++			}
++			off += RMTFS_SECTOR_SIZE;
++		}
++
++		if (!logged) {
++			pr_info("RW_IOVEC caller %u %s: sector %u+%u ('%s')\n",
++				req->caller_id, is_write ? "write" : "read",
++				e->sector_addr, e->num_sector, c->part->path);
++			logged = true;
++		}
++	}
++
++out:
++	if (ret) {
++		resp.result.result = QMI_RESULT_FAILURE_V01;
++		resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++	} else {
++		resp.result.result = QMI_RESULT_SUCCESS_V01;
++		resp.result.error = QMI_RMTFS_ERR_NONE;
++	}
++	mutex_unlock(&rmtfs_lock);
++
++	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_RW_IOVEC,
++				sizeof(struct rmtfs_iovec_resp),
++				rmtfs_iovec_resp_ei, &resp);
++	if (ret < 0)
++		pr_err("RW_IOVEC: failed to send response: %d\n", ret);
++}
++
++/*
++ * ALLOC_BUFF: the modem asks for a scratch buffer of buff_size bytes in the
++ * shared region. Like linux-msm/rmtfs, we hand back the base physical address
++ * of the region (there is a single shared arena; the modem serialises its own
++ * use of it), after checking the request fits.
++ */
++static void rmtfs_handle_alloc(struct qmi_handle *qmi, struct sockaddr_qrtr *sq,
++			       struct qmi_txn *txn, const void *decoded)
++{
++	const struct rmtfs_alloc_buf_req *req = decoded;
++	struct rmtfs_alloc_buf_resp resp = {};
++	int ret;
++
++	mutex_lock(&rmtfs_lock);
++
++	if (!rmtfs_shmem || req->buff_size > rmtfs_shmem_size) {
++		pr_err("ALLOC_BUFF caller %u: size %u exceeds shmem %zu\n",
++		       req->caller_id, req->buff_size, rmtfs_shmem_size);
++		resp.result.result = QMI_RESULT_FAILURE_V01;
++		resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++	} else {
++		resp.result.result = QMI_RESULT_SUCCESS_V01;
++		resp.result.error = QMI_RMTFS_ERR_NONE;
++		resp.buff_address_valid = 1;
++		resp.buff_address = rmtfs_shmem_base;
++		pr_info("ALLOC_BUFF caller %u: %u bytes -> 0x%llx\n",
++			req->caller_id, req->buff_size,
++			(unsigned long long)resp.buff_address);
++	}
++
++	mutex_unlock(&rmtfs_lock);
++
++	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_ALLOC_BUFF,
++				sizeof(struct rmtfs_alloc_buf_resp),
++				rmtfs_alloc_buf_resp_ei, &resp);
++	if (ret < 0)
++		pr_err("ALLOC_BUFF: failed to send response: %d\n", ret);
++}
++
++static void rmtfs_handle_dev_error(struct qmi_handle *qmi,
++				   struct sockaddr_qrtr *sq,
++				   struct qmi_txn *txn, const void *decoded)
++{
++	const struct rmtfs_dev_error_req *req = decoded;
++	struct rmtfs_dev_error_resp resp = {};
++	struct rmtfs_caller *c;
++	int ret;
++
++	mutex_lock(&rmtfs_lock);
++	c = rmtfs_find_caller(req->caller_id, sq->sq_node);
++	if (c) {
++		resp.result.result = QMI_RESULT_SUCCESS_V01;
++		resp.result.error = QMI_RMTFS_ERR_NONE;
++		resp.status_valid = 1;
++		resp.status = c->dev_error;
++	} else {
++		resp.result.result = QMI_RESULT_FAILURE_V01;
++		resp.result.error = QMI_RMTFS_ERR_INTERNAL;
++	}
++	mutex_unlock(&rmtfs_lock);
++
++	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_GET_DEV_ERROR,
++				sizeof(struct rmtfs_dev_error_resp),
++				rmtfs_dev_error_resp_ei, &resp);
++	if (ret < 0)
++		pr_err("GET_DEV_ERROR: failed to send response: %d\n", ret);
++}
++
++static const struct qmi_msg_handler rmtfs_msg_handlers[] = {
++	{
++		.type		= QMI_REQUEST,
++		.msg_id		= QMI_RMTFS_OPEN,
++		.ei		= rmtfs_open_req_ei,
++		.decoded_size	= sizeof(struct rmtfs_open_req),
++		.fn		= rmtfs_handle_open,
++	},
++	{
++		.type		= QMI_REQUEST,
++		.msg_id		= QMI_RMTFS_CLOSE,
++		.ei		= rmtfs_close_req_ei,
++		.decoded_size	= sizeof(struct rmtfs_close_req),
++		.fn		= rmtfs_handle_close,
++	},
++	{
++		.type		= QMI_REQUEST,
++		.msg_id		= QMI_RMTFS_RW_IOVEC,
++		.ei		= rmtfs_iovec_req_ei,
++		.decoded_size	= sizeof(struct rmtfs_iovec_req),
++		.fn		= rmtfs_handle_iovec,
++	},
++	{
++		.type		= QMI_REQUEST,
++		.msg_id		= QMI_RMTFS_ALLOC_BUFF,
++		.ei		= rmtfs_alloc_buf_req_ei,
++		.decoded_size	= sizeof(struct rmtfs_alloc_buf_req),
++		.fn		= rmtfs_handle_alloc,
++	},
++	{
++		.type		= QMI_REQUEST,
++		.msg_id		= QMI_RMTFS_GET_DEV_ERROR,
++		.ei		= rmtfs_dev_error_req_ei,
++		.decoded_size	= sizeof(struct rmtfs_dev_error_req),
++		.fn		= rmtfs_handle_dev_error,
++	},
++	{}
++};
++
++/*
++ * The modem crash-loops until rmtfs is up and drops all its clients on each
++ * restart. Release any per-caller state (RAM shadows) when the name service
++ * resets or a client goes away, so a fresh modem boot starts clean.
++ */
++static void rmtfs_release_node(unsigned int node)
++{
++	int i;
++
++	mutex_lock(&rmtfs_lock);
++	for (i = 0; i < RMTFS_MAX_CALLERS; i++) {
++		if (rmtfds[i].in_use && rmtfds[i].node == node)
++			rmtfs_caller_release(&rmtfds[i]);
++	}
++	mutex_unlock(&rmtfs_lock);
++}
++
++static void rmtfs_ops_bye(struct qmi_handle *qmi, unsigned int node)
++{
++	pr_info("node %u gone, releasing callers\n", node);
++	rmtfs_release_node(node);
++}
++
++static void rmtfs_ops_del_client(struct qmi_handle *qmi, unsigned int node,
++				 unsigned int port)
++{
++	int i;
++
++	mutex_lock(&rmtfs_lock);
++	for (i = 0; i < RMTFS_MAX_CALLERS; i++) {
++		if (rmtfds[i].in_use && rmtfds[i].node == node)
++			rmtfs_caller_release(&rmtfds[i]);
++	}
++	mutex_unlock(&rmtfs_lock);
++}
++
++static void rmtfs_ops_net_reset(struct qmi_handle *qmi)
++{
++	int i;
++
++	pr_info("name service reset, releasing all callers\n");
++	mutex_lock(&rmtfs_lock);
++	for (i = 0; i < RMTFS_MAX_CALLERS; i++)
++		rmtfs_caller_release(&rmtfds[i]);
++	mutex_unlock(&rmtfs_lock);
++}
++
++static const struct qmi_ops rmtfs_qmi_ops = {
++	.bye		= rmtfs_ops_bye,
++	.del_client	= rmtfs_ops_del_client,
++	.net_reset	= rmtfs_ops_net_reset,
++};
++
++/* ---- lifecycle ---- */
++
++static struct task_struct *rmtfs_thread;
++
++static int rmtfs_start(void)
++{
++	int ret;
++
++	ret = rmtfs_map_shmem();
++	if (ret)
++		return ret;
++
++	ret = qmi_handle_init(&rmtfs_qmi, sizeof(struct rmtfs_iovec_req),
++			      &rmtfs_qmi_ops, rmtfs_msg_handlers);
++	if (ret) {
++		pr_err("failed to init QMI handle: %d\n", ret);
++		return ret;
++	}
++
++	ret = qmi_add_server(&rmtfs_qmi, RMTFS_SERVICE, RMTFS_VERSION,
++			     RMTFS_INSTANCE);
++	if (ret) {
++		pr_err("failed to add QMI server: %d\n", ret);
++		qmi_handle_release(&rmtfs_qmi);
++		return ret;
++	}
++
++	rmtfs_qmi_ready = true;
++	pr_info("published rmtfs QMI service %d (v%d instance %d)\n",
++		RMTFS_SERVICE, RMTFS_VERSION, RMTFS_INSTANCE);
++	return 0;
++}
++
++/*
++ * Bring-up runs in a kthread so we can retry: qrtr may still be coming up at
++ * late_initcall time. The modem retries its EFS access for ~40s, so a few
++ * seconds of retry here is well within budget.
++ */
++static int rmtfs_kthread(void *data)
++{
++	while (!kthread_should_stop()) {
++		if (!rmtfs_start())
++			break;
++		schedule_timeout_interruptible(HZ);
++	}
++	return 0;
++}
++
++static int __init rmtfs_serv_init(void)
++{
++	rmtfs_thread = kthread_run(rmtfs_kthread, NULL, "qcom_rmtfs_serv");
++	if (IS_ERR(rmtfs_thread)) {
++		pr_err("failed to start kthread: %ld\n", PTR_ERR(rmtfs_thread));
++		return PTR_ERR(rmtfs_thread);
++	}
++	return 0;
++}
++
++static void __exit rmtfs_serv_exit(void)
++{
++	int i;
++
++	if (rmtfs_thread)
++		kthread_stop(rmtfs_thread);
++	if (rmtfs_qmi_ready)
++		qmi_handle_release(&rmtfs_qmi);
++
++	mutex_lock(&rmtfs_lock);
++	for (i = 0; i < RMTFS_MAX_CALLERS; i++)
++		rmtfs_caller_release(&rmtfds[i]);
++	mutex_unlock(&rmtfs_lock);
++
++	if (rmtfs_shmem)
++		memunmap(rmtfs_shmem);
++}
++
++/* late_initcall: run after qrtr and the block layer are up. */
++late_initcall(rmtfs_serv_init);
++module_exit(rmtfs_serv_exit);
++
++MODULE_DESCRIPTION("In-kernel Qualcomm remote filesystem (rmtfs) QMI service");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0

--- a/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
+++ b/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
@@ -30,10 +30,11 @@ its encode buffer from the len argument and returns -ETOOSMALL otherwise.
 The modem's first OPEN typically races UFS probe; since a QMI failure makes
 the modem fatal instantly, OPEN polls for the backing partition (up to 60s)
 before answering. Callers are keyed on (node, caller_id) and survive client
-sockets closing: DEL_CLIENT is a deliberate no-op like in userspace rmtfs
-(the modem opens each caller from its own transient socket and other modem
-QMI clients disconnect constantly); per-node state is released only on BYE
-and net_reset.
+sockets closing: DEL_CLIENT is a deliberate no-op like in userspace rmtfs;
+per-node state is released only on BYE and net_reset. The RW_IOVEC iovec
+array accepts up to 512 entries with a 16-bit wire length prefix: the
+userspace IDL says 255/u8 but the modem firmware demonstrably sends a u16
+prefix with 257 entries in its first RW_IOVEC.
 
 ---
 diff --git a/drivers/soc/qcom/Kconfig b/drivers/soc/qcom/Kconfig
@@ -75,10 +76,10 @@ index 7903de1ee..de19d30e9 100644
  obj-$(CONFIG_QCOM_PMIC_PDCHARGER_ULOG)	+= pmic_pdcharger_ulog.o
 diff --git a/drivers/soc/qcom/qcom_rmtfs_serv.c b/drivers/soc/qcom/qcom_rmtfs_serv.c
 new file mode 100644
-index 000000000..f6b01b189
+index 000000000..095d60579
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_rmtfs_serv.c
-@@ -0,0 +1,1263 @@
+@@ -0,0 +1,1276 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * In-kernel Qualcomm remote filesystem (rmtfs) QMI service.
@@ -167,8 +168,15 @@ index 000000000..f6b01b189
 + */
 +#define RMTFS_SHADOW_CAP		(16 * 1024 * 1024)
 +
-+/* Max iovec entries in one RW_IOVEC (rmtfs_iovec_req.iovec is [255]) */
-+#define RMTFS_MAX_IOVEC			255
++/*
++ * Max iovec entries in one RW_IOVEC. The userspace linux-msm/rmtfs IDL says
++ * 255 with a u8 length prefix, but the modem firmware on the comma four
++ * demonstrably sends a u16 length prefix with 257 entries in its first
++ * RW_IOVEC, so its own IDL allows more. Accept up to 512. (The kernel QMI
++ * codec picks the wire prefix width from the DATA_LEN element's elem_size:
++ * u8 -> 1 byte, otherwise 2 bytes; see qmi_encdec.c.)
++ */
++#define RMTFS_MAX_IOVEC			512
 +
 +/*
 + * Maximum ENCODED (wire TLV) response sizes. qmi_send_response() sizes its
@@ -191,10 +199,10 @@ index 000000000..f6b01b189
 +
 +/*
 + * Receive-buffer size for incoming requests. The largest is RW_IOVEC:
-+ * caller_id(4) + direction(1) + iovec array (1-byte count + 255 * 12) +
-+ * is_force_sync(1), each TLV-framed (~3080 bytes). Rounded up generously.
++ * caller_id(4) + direction(1) + iovec array (2-byte count + 512 * 12) +
++ * is_force_sync(1), each TLV-framed (~6170 bytes). Rounded up generously.
 + */
-+#define RMTFS_MAX_MSG_LEN		4096
++#define RMTFS_MAX_MSG_LEN		8192
 +
 +/* How long OPEN waits for the backing partition to appear (UFS probe) */
 +#define RMTFS_PART_WAIT_MS		60000
@@ -436,9 +444,15 @@ index 000000000..f6b01b189
 +		.offset		= offsetof(struct rmtfs_iovec_req, direction),
 +	},
 +	{
++		/*
++		 * elem_size != sizeof(u8) selects a 16-bit wire length prefix,
++		 * matching what the modem actually sends (its first RW_IOVEC
++		 * carries 257 entries). The decoded value is always stored as
++		 * a u32 in iovec_len regardless of elem_size.
++		 */
 +		.data_type	= QMI_DATA_LEN,
 +		.elem_len	= 1,
-+		.elem_size	= sizeof(u32),
++		.elem_size	= sizeof(u16),
 +		.array_type	= NO_ARRAY,
 +		.tlv_type	= 0x03,
 +		.offset		= offsetof(struct rmtfs_iovec_req, iovec_len),

--- a/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
+++ b/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
@@ -169,14 +169,14 @@ index 000000000..095d60579
 +#define RMTFS_SHADOW_CAP		(16 * 1024 * 1024)
 +
 +/*
-+ * Max iovec entries in one RW_IOVEC. The userspace linux-msm/rmtfs IDL says
-+ * 255 with a u8 length prefix, but the modem firmware on the comma four
-+ * demonstrably sends a u16 length prefix with 257 entries in its first
-+ * RW_IOVEC, so its own IDL allows more. Accept up to 512. (The kernel QMI
-+ * codec picks the wire prefix width from the DATA_LEN element's elem_size:
-+ * u8 -> 1 byte, otherwise 2 bytes; see qmi_encdec.c.)
++ * Max iovec entries in one RW_IOVEC. Matches the userspace linux-msm/rmtfs
++ * IDL: u8 length prefix, at most 255 entries. Confirmed on-device: the
++ * modem's first RW_IOVEC TLV is 11 bytes = 1-byte count (1) followed by a
++ * single 10-byte iovec entry. (The kernel QMI codec picks the wire prefix
++ * width from the DATA_LEN element's elem_size: u8 -> 1 byte, otherwise
++ * 2 bytes; see qmi_encdec.c.)
 + */
-+#define RMTFS_MAX_IOVEC			512
++#define RMTFS_MAX_IOVEC			255
 +
 +/*
 + * Maximum ENCODED (wire TLV) response sizes. qmi_send_response() sizes its
@@ -445,14 +445,14 @@ index 000000000..095d60579
 +	},
 +	{
 +		/*
-+		 * elem_size != sizeof(u8) selects a 16-bit wire length prefix,
-+		 * matching what the modem actually sends (its first RW_IOVEC
-+		 * carries 257 entries). The decoded value is always stored as
-+		 * a u32 in iovec_len regardless of elem_size.
++		 * u8 wire length prefix, per the rmtfs QMI IDL (max 255
++		 * entries). Confirmed on-device: the modem's RW_IOVEC TLV is
++		 * 11 bytes = 1-byte count (1) + one 10-byte iovec entry. The
++		 * decoded value is always stored as a u32 in iovec_len.
 +		 */
 +		.data_type	= QMI_DATA_LEN,
 +		.elem_len	= 1,
-+		.elem_size	= sizeof(u16),
++		.elem_size	= sizeof(u8),
 +		.array_type	= NO_ARRAY,
 +		.tlv_type	= 0x03,
 +		.offset		= offsetof(struct rmtfs_iovec_req, iovec_len),

--- a/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
+++ b/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
@@ -21,6 +21,14 @@ symlinks are needed. RW_IOVEC payload moves through the reserved qcom,rmtfs-mem
 region, which the existing qcom_rmtfs_mem driver still SCM-assigns to the
 modem; this service only additionally memremaps it.
 
+Response buffers are sized by encoded TLV length (3-byte TLV header per
+element plus payload), not decoded struct size, as qmi_send_response() sizes
+its encode buffer from the len argument and returns -ETOOSMALL otherwise.
+The modem's first OPEN typically races UFS probe; since a QMI failure makes
+the modem fatal instantly, OPEN polls for the backing partition (up to 60s)
+before answering. Blocking is safe: the QMI handle runs handlers on its own
+ordered workqueue and the modem is the only client.
+
 ---
 diff --git a/drivers/soc/qcom/Kconfig b/drivers/soc/qcom/Kconfig
 index 0922d0cb5..fe616cbad 100644
@@ -61,10 +69,10 @@ index 7903de1ee..de19d30e9 100644
  obj-$(CONFIG_QCOM_PMIC_PDCHARGER_ULOG)	+= pmic_pdcharger_ulog.o
 diff --git a/drivers/soc/qcom/qcom_rmtfs_serv.c b/drivers/soc/qcom/qcom_rmtfs_serv.c
 new file mode 100644
-index 000000000..e82330b3d
+index 000000000..30b2de29d
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_rmtfs_serv.c
-@@ -0,0 +1,1156 @@
+@@ -0,0 +1,1208 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * In-kernel Qualcomm remote filesystem (rmtfs) QMI service.
@@ -100,6 +108,7 @@ index 000000000..e82330b3d
 +#define pr_fmt(fmt) "rmtfs: " fmt
 +
 +#include <linux/blkdev.h>
++#include <linux/delay.h>
 +#include <linux/fs.h>
 +#include <linux/io.h>
 +#include <linux/kernel.h>
@@ -146,6 +155,36 @@ index 000000000..e82330b3d
 +
 +/* Max iovec entries in one RW_IOVEC (rmtfs_iovec_req.iovec is [255]) */
 +#define RMTFS_MAX_IOVEC			255
++
++/*
++ * Maximum ENCODED (wire TLV) response sizes. qmi_send_response() sizes its
++ * encode buffer from the len argument, so these must cover the encoded TLVs
++ * (each TLV costs 3 bytes of type+length header plus its payload), NOT the
++ * decoded C struct size, which lacks the TLV headers (using sizeof() here
++ * made the encoder return -ETOOSMALL).
++ */
++#define RMTFS_TLV(payload)		(3 + (payload))
++/* result(4) + caller_id(4) */
++#define RMTFS_OPEN_RESP_MAX_LEN		(RMTFS_TLV(4) + RMTFS_TLV(4))
++/* result(4) */
++#define RMTFS_CLOSE_RESP_MAX_LEN	RMTFS_TLV(4)
++/* result(4) */
++#define RMTFS_IOVEC_RESP_MAX_LEN	RMTFS_TLV(4)
++/* result(4) + buff_address(8) */
++#define RMTFS_ALLOC_RESP_MAX_LEN	(RMTFS_TLV(4) + RMTFS_TLV(8))
++/* result(4) + status(1) */
++#define RMTFS_DEV_ERROR_RESP_MAX_LEN	(RMTFS_TLV(4) + RMTFS_TLV(1))
++
++/*
++ * Receive-buffer size for incoming requests. The largest is RW_IOVEC:
++ * caller_id(4) + direction(1) + iovec array (1-byte count + 255 * 12) +
++ * is_force_sync(1), each TLV-framed (~3080 bytes). Rounded up generously.
++ */
++#define RMTFS_MAX_MSG_LEN		4096
++
++/* How long OPEN waits for the backing partition to appear (UFS probe) */
++#define RMTFS_PART_WAIT_MS		60000
++#define RMTFS_PART_POLL_MS		250
 +
 +/*
 + * Path -> GPT partlabel mapping. The modem opens the "/boot/modem_*" virtual
@@ -640,11 +679,32 @@ index 000000000..e82330b3d
 +	u8 *buf;
 +	int ret;
 +
++	/*
++	 * The modem's first OPEN typically arrives before UFS has finished
++	 * probing, so the backing partition may not exist yet. Answering with
++	 * a QMI failure makes the modem fatal immediately (it does not use
++	 * its own retry budget for OPEN errors), so instead poll for the
++	 * partition here. Blocking is fine: the QMI handle runs handlers on
++	 * its own ordered workqueue and the modem is our only client, so
++	 * nothing else is stalled while we wait.
++	 */
 +	ret = rmtfs_devt_from_partlabel(part->partlabel, &devt);
 +	if (ret) {
-+		pr_err("partition '%s' not found (UFS not up yet?)\n",
-+		       part->partlabel);
-+		return ret;
++		unsigned long timeout = jiffies +
++					msecs_to_jiffies(RMTFS_PART_WAIT_MS);
++
++		pr_info("waiting for partition '%s' to appear (UFS still probing?)\n",
++			part->partlabel);
++		while (ret && time_before(jiffies, timeout)) {
++			msleep(RMTFS_PART_POLL_MS);
++			ret = rmtfs_devt_from_partlabel(part->partlabel, &devt);
++		}
++		if (ret) {
++			pr_err("partition '%s' did not appear within %d ms\n",
++			       part->partlabel, RMTFS_PART_WAIT_MS);
++			return ret;
++		}
++		pr_info("partition '%s' appeared\n", part->partlabel);
 +	}
 +
 +	bdev_file = bdev_file_open_by_dev(devt, BLK_OPEN_READ, &rmtfds, NULL);
@@ -830,7 +890,7 @@ index 000000000..e82330b3d
 +
 +respond:
 +	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_OPEN,
-+				sizeof(struct rmtfs_open_resp),
++				RMTFS_OPEN_RESP_MAX_LEN,
 +				rmtfs_open_resp_ei, &resp);
 +	if (ret < 0)
 +		pr_err("OPEN: failed to send response: %d\n", ret);
@@ -872,7 +932,7 @@ index 000000000..e82330b3d
 +	mutex_unlock(&rmtfs_lock);
 +
 +	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_CLOSE,
-+				sizeof(struct rmtfs_close_resp),
++				RMTFS_CLOSE_RESP_MAX_LEN,
 +				rmtfs_close_resp_ei, &resp);
 +	if (ret < 0)
 +		pr_err("CLOSE: failed to send response: %d\n", ret);
@@ -973,7 +1033,7 @@ index 000000000..e82330b3d
 +	mutex_unlock(&rmtfs_lock);
 +
 +	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_RW_IOVEC,
-+				sizeof(struct rmtfs_iovec_resp),
++				RMTFS_IOVEC_RESP_MAX_LEN,
 +				rmtfs_iovec_resp_ei, &resp);
 +	if (ret < 0)
 +		pr_err("RW_IOVEC: failed to send response: %d\n", ret);
@@ -1012,7 +1072,7 @@ index 000000000..e82330b3d
 +	mutex_unlock(&rmtfs_lock);
 +
 +	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_ALLOC_BUFF,
-+				sizeof(struct rmtfs_alloc_buf_resp),
++				RMTFS_ALLOC_RESP_MAX_LEN,
 +				rmtfs_alloc_buf_resp_ei, &resp);
 +	if (ret < 0)
 +		pr_err("ALLOC_BUFF: failed to send response: %d\n", ret);
@@ -1041,7 +1101,7 @@ index 000000000..e82330b3d
 +	mutex_unlock(&rmtfs_lock);
 +
 +	ret = qmi_send_response(qmi, sq, txn, QMI_RMTFS_GET_DEV_ERROR,
-+				sizeof(struct rmtfs_dev_error_resp),
++				RMTFS_DEV_ERROR_RESP_MAX_LEN,
 +				rmtfs_dev_error_resp_ei, &resp);
 +	if (ret < 0)
 +		pr_err("GET_DEV_ERROR: failed to send response: %d\n", ret);
@@ -1151,7 +1211,7 @@ index 000000000..e82330b3d
 +	if (ret)
 +		return ret;
 +
-+	ret = qmi_handle_init(&rmtfs_qmi, sizeof(struct rmtfs_iovec_req),
++	ret = qmi_handle_init(&rmtfs_qmi, RMTFS_MAX_MSG_LEN,
 +			      &rmtfs_qmi_ops, rmtfs_msg_handlers);
 +	if (ret) {
 +		pr_err("failed to init QMI handle: %d\n", ret);

--- a/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
+++ b/kernel/patches/0015-driver-soc-qcom-rmtfs-service.patch
@@ -11,23 +11,29 @@ Required on comma devices where the proprietary Qualcomm userspace is inert.
 
 EFS lives in the modemst1/modemst2/fsc/fsg GPT partitions (factory
 calibration/provisioning). To eliminate any risk of corrupting that data,
-on-flash EFS is treated as strictly read-only: each backing partition is
-shadowed in RAM on first access, reads are served from the shadow, and writes
-are applied only to the shadow (never written back to flash). This mirrors the
-userspace daemon's read-only shadow mode, which is how vamOS runs it
-(rmtfs -r -s -P). Partitions are resolved by GPT partlabel entirely in-kernel
-(matching bd_meta_info->volname across block_class), so no udev by-partlabel
-symlinks are needed. RW_IOVEC payload moves through the reserved qcom,rmtfs-mem
-region, which the existing qcom_rmtfs_mem driver still SCM-assigns to the
-modem; this service only additionally memremaps it.
+on-flash EFS is treated as strictly read-only: the head of each backing
+partition (up to a 16MiB cap; fsc on the comma four is ~1.5GiB but the modem
+only uses a small cookie area at its start) is shadowed in RAM on first
+access, reads are served from the shadow (zeros beyond it), and writes are
+applied only to the shadow (never written back to flash; beyond the cap they
+are accepted and dropped). This mirrors the userspace daemon's read-only
+shadow mode, which is how vamOS runs it (rmtfs -r -s -P). Partitions are
+resolved by GPT partlabel entirely in-kernel (matching bd_meta_info->volname
+across block_class), so no udev by-partlabel symlinks are needed. RW_IOVEC
+payload moves through the reserved qcom,rmtfs-mem region, which the existing
+qcom_rmtfs_mem driver still SCM-assigns to the modem; this service only
+additionally memremaps it.
 
 Response buffers are sized by encoded TLV length (3-byte TLV header per
 element plus payload), not decoded struct size, as qmi_send_response() sizes
 its encode buffer from the len argument and returns -ETOOSMALL otherwise.
 The modem's first OPEN typically races UFS probe; since a QMI failure makes
 the modem fatal instantly, OPEN polls for the backing partition (up to 60s)
-before answering. Blocking is safe: the QMI handle runs handlers on its own
-ordered workqueue and the modem is the only client.
+before answering. Callers are keyed on (node, caller_id) and survive client
+sockets closing: DEL_CLIENT is a deliberate no-op like in userspace rmtfs
+(the modem opens each caller from its own transient socket and other modem
+QMI clients disconnect constantly); per-node state is released only on BYE
+and net_reset.
 
 ---
 diff --git a/drivers/soc/qcom/Kconfig b/drivers/soc/qcom/Kconfig
@@ -69,10 +75,10 @@ index 7903de1ee..de19d30e9 100644
  obj-$(CONFIG_QCOM_PMIC_PDCHARGER_ULOG)	+= pmic_pdcharger_ulog.o
 diff --git a/drivers/soc/qcom/qcom_rmtfs_serv.c b/drivers/soc/qcom/qcom_rmtfs_serv.c
 new file mode 100644
-index 000000000..30b2de29d
+index 000000000..f6b01b189
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_rmtfs_serv.c
-@@ -0,0 +1,1208 @@
+@@ -0,0 +1,1263 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * In-kernel Qualcomm remote filesystem (rmtfs) QMI service.
@@ -89,9 +95,10 @@ index 000000000..30b2de29d
 + *   The modem's EFS lives in the modemst1/modemst2/fsc/fsg GPT partitions,
 + *   which hold factory calibration and provisioning data. To eliminate any
 + *   risk of corrupting that data we treat on-flash EFS as strictly READ-ONLY:
-+ *   on first access each backing partition is copied in full into a RAM shadow
-+ *   buffer; reads are served from the shadow, and writes are applied ONLY to
-+ *   the shadow (never written back to flash). This keeps the modem happy
++ *   on first access the head of each backing partition (up to a 16MiB cap) is
++ *   copied into a RAM shadow buffer; reads are served from the shadow (zeros
++ *   beyond it), and writes are applied ONLY to the shadow (never written back
++ *   to flash; writes beyond the cap are accepted and dropped). This keeps the modem happy
 + *   (its writes "succeed") with zero risk to the factory partitions. This
 + *   mirrors the userspace daemon's -r (read-only) shadow-buffer behaviour,
 + *   which is how vamOS runs it (rmtfs -r -s -P).
@@ -150,8 +157,15 @@ index 000000000..30b2de29d
 +/* Longest path the modem may request (rmtfs_open_req.path is char[256]) */
 +#define RMTFS_MAX_PATH			256
 +
-+/* Refuse to shadow a partition larger than this (EFS partitions are small) */
-+#define RMTFS_MAX_SHADOW		(16 * 1024 * 1024)
++/*
++ * RAM-shadow cap. Most EFS partitions are ~2MiB, but on the comma four the
++ * fsc partition is ~1.5GiB; the modem only uses a tiny cookie area at its
++ * start. We shadow at most this much of a partition: reads beyond the cap
++ * return zeros and writes beyond it are accepted but dropped (logged once
++ * per caller). The rmtfs protocol never reports a size to the modem, so a
++ * capped shadow is invisible at the protocol level.
++ */
++#define RMTFS_SHADOW_CAP		(16 * 1024 * 1024)
 +
 +/* Max iovec entries in one RW_IOVEC (rmtfs_iovec_req.iovec is [255]) */
 +#define RMTFS_MAX_IOVEC			255
@@ -216,6 +230,10 @@ index 000000000..30b2de29d
 +	/* RAM shadow of the backing partition (read-only w.r.t. flash) */
 +	u8 *shadow;
 +	size_t shadow_len;
++
++	/* log-once flags for accesses beyond the capped shadow */
++	bool warned_read_past;
++	bool warned_write_drop;
 +
 +	u32 dev_error;
 +};
@@ -716,11 +734,23 @@ index 000000000..30b2de29d
 +	}
 +
 +	size = bdev_nr_bytes(file_bdev(bdev_file));
-+	if (size <= 0 || size > RMTFS_MAX_SHADOW) {
++	if (size <= 0) {
 +		pr_err("partition '%s' has implausible size %lld, refusing\n",
 +		       part->partlabel, size);
 +		ret = -EFBIG;
 +		goto out_close;
++	}
++
++	/*
++	 * Clamp the shadow: fsc on the comma four is ~1.5GiB but the modem
++	 * only touches a small cookie area at its start. Shadow just the
++	 * head of the partition; accesses beyond the cap are handled in
++	 * rmtfs_shadow_read/write (zeros / dropped).
++	 */
++	if (size > RMTFS_SHADOW_CAP) {
++		pr_info("partition '%s' is %lld bytes, shadowing first %d only\n",
++			part->partlabel, size, RMTFS_SHADOW_CAP);
++		size = RMTFS_SHADOW_CAP;
 +	}
 +
 +	buf = vmalloc(size);
@@ -753,8 +783,9 @@ index 000000000..30b2de29d
 +}
 +
 +/*
-+ * Serve a sector read from the RAM shadow, zero-padding past EOF.
-+ * Mirrors linux-msm/rmtfs storage_pread shadow behaviour.
++ * Serve a sector read from the RAM shadow, zero-padding past its end
++ * (partition EOF or the shadow cap). Mirrors linux-msm/rmtfs storage_pread
++ * shadow behaviour.
 + */
 +static void rmtfs_shadow_read(struct rmtfs_caller *c, u8 *dst, loff_t off,
 +			      size_t len)
@@ -765,8 +796,15 @@ index 000000000..30b2de29d
 +		avail = min_t(size_t, len, c->shadow_len - off);
 +	if (avail)
 +		memcpy(dst, c->shadow + off, avail);
-+	if (avail < len)
++	if (avail < len) {
 +		memset(dst + avail, 0, len - avail);
++		if (!c->warned_read_past) {
++			c->warned_read_past = true;
++			pr_info("caller %u ('%s'): read at %lld beyond shadow (%zu bytes), serving zeros\n",
++				c->id, c->part->path, (long long)off,
++				c->shadow_len);
++		}
++	}
 +}
 +
 +/*
@@ -777,8 +815,19 @@ index 000000000..30b2de29d
 +static int rmtfs_shadow_write(struct rmtfs_caller *c, const u8 *src,
 +			      loff_t off, size_t len)
 +{
-+	if (off < 0 || len > RMTFS_MAX_SHADOW || off > RMTFS_MAX_SHADOW - len)
-+		return -EFBIG;
++	if (off < 0 || len > RMTFS_SHADOW_CAP || off > RMTFS_SHADOW_CAP - len) {
++		/*
++		 * Beyond the shadow cap: accept and drop. The write "succeeds"
++		 * from the modem's point of view but is not retained (it was
++		 * never going to reach flash either way).
++		 */
++		if (!c->warned_write_drop) {
++			c->warned_write_drop = true;
++			pr_info("caller %u ('%s'): write at %lld beyond shadow cap, accepted and dropped\n",
++				c->id, c->part->path, (long long)off);
++		}
++		return 0;
++	}
 +
 +	if (off + len > c->shadow_len) {
 +		size_t newlen = off + len;
@@ -808,6 +857,8 @@ index 000000000..30b2de29d
 +	c->in_use = false;
 +	c->part = NULL;
 +	c->node = 0;
++	c->warned_read_past = false;
++	c->warned_write_drop = false;
 +	c->dev_error = 0;
 +}
 +
@@ -1147,9 +1198,22 @@ index 000000000..30b2de29d
 +};
 +
 +/*
-+ * The modem crash-loops until rmtfs is up and drops all its clients on each
-+ * restart. Release any per-caller state (RAM shadows) when the name service
-+ * resets or a client goes away, so a fresh modem boot starts clean.
++ * Caller lifecycle vs QRTR events (mirrors linux-msm/rmtfs):
++ *
++ * Callers are keyed on (node, caller_id) and must SURVIVE individual client
++ * sockets closing. The modem opens each rmtfs caller from its own transient
++ * QMI socket (fs1 from 0:8, fsc from 0:12, ...), and its other subsystems'
++ * QMI clients on the same node connect/disconnect constantly, so DEL_CLIENT
++ * fires routinely while callers are still live. The userspace daemon treats
++ * both DEL_CLIENT and BYE as no-ops. Releasing callers on DEL_CLIENT freed
++ * slots the modem still held and caused duplicate caller_ids being handed
++ * out (fs1 and fsg both got id 0).
++ *
++ * We release per-node state only on BYE (the whole node is gone, i.e. the
++ * modem stopped/crashed, so its caller_ids are dead) and on net_reset. A
++ * restarting modem re-OPENs everything anyway, and the OPEN handler also
++ * reuses an existing (node, partition) slot, so slots cannot leak across
++ * modem crash-loops.
 + */
 +static void rmtfs_release_node(unsigned int node)
 +{
@@ -1165,21 +1229,18 @@ index 000000000..30b2de29d
 +
 +static void rmtfs_ops_bye(struct qmi_handle *qmi, unsigned int node)
 +{
-+	pr_info("node %u gone, releasing callers\n", node);
++	pr_info("node %u gone, releasing its callers\n", node);
 +	rmtfs_release_node(node);
 +}
 +
 +static void rmtfs_ops_del_client(struct qmi_handle *qmi, unsigned int node,
 +				 unsigned int port)
 +{
-+	int i;
-+
-+	mutex_lock(&rmtfs_lock);
-+	for (i = 0; i < RMTFS_MAX_CALLERS; i++) {
-+		if (rmtfds[i].in_use && rmtfds[i].node == node)
-+			rmtfs_caller_release(&rmtfds[i]);
-+	}
-+	mutex_unlock(&rmtfs_lock);
++	/*
++	 * Deliberate no-op (mirrors userspace rmtfs): a single client socket
++	 * closing does not invalidate the caller_ids of its node.
++	 */
++	pr_debug("del_client %u:%u (ignored)\n", node, port);
 +}
 +
 +static void rmtfs_ops_net_reset(struct qmi_handle *qmi)


### PR DESCRIPTION
Brings up WiFi on mainline with unmodified AGNOS userspace: in-kernel rmtfs and tqftpserv provide the modem firmware chain, and device-matched wlanmdsp.mbn plus SOM-tuned board data (via qcom,calibration-variant) fix the 5 GHz DFS firmware crash. Verified on mici: cold boot associates on ch100 (DFS) with no errors.