### PR TITLE
WCN3990 wifi: device-matched wlanmdsp and SOM-tuned board data

### DIFF
--- a/kernel/dts/sdm845-comma-mici.dts
+++ b/kernel/dts/sdm845-comma-mici.dts
@@ -59,3 +59,7 @@
 &uart3 {
 	status = "okay";
 };
+
+&wifi {
+	qcom,calibration-variant = "comma-mici";
+};

--- a/kernel/dts/sdm845-comma-tizi.dts
+++ b/kernel/dts/sdm845-comma-tizi.dts
@@ -63,3 +63,7 @@
 	remote-endpoint = <&panel_in>;
 	data-lanes = <0 1 2 3>;
 };
+
+&wifi {
+	qcom,calibration-variant = "comma-tizi";
+};

--- a/kernel/firmware/ath10k/WCN3990/hw1.0/board-2.bin
+++ b/kernel/firmware/ath10k/WCN3990/hw1.0/board-2.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:867e1010787764020653812167d93f5952cbbea05f576209d953d8c9322f18aa
-size 867116
+oid sha256:a6f2b5ba06d33bae9d0ec525b84b267ff0a26f4fde4e96a5b586e73096cfd769
+size 905596

--- a/kernel/firmware/ath10k/WCN3990/hw1.0/wlanmdsp.mbn
+++ b/kernel/firmware/ath10k/WCN3990/hw1.0/wlanmdsp.mbn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92e1501254e6de78c0f2e2cf091507d488b608d07e53acd14813a82744823ec2
-size 3725044
+oid sha256:aa7a7b3ef5e4c43a242e7bca199b1bb358c1111ddfc39dcdecd9eba7473feb31
+size 3379868


### PR DESCRIPTION
fixes the 5GHz crashing seen during comma hack, working on home network