### PR TITLE
kernel: fix Wi-Fi RX instability and bogus MAC address

### DIFF
--- a/kernel/patches/0011-wifi-set-mac-from-soc-serial-number.patch
+++ b/kernel/patches/0011-wifi-set-mac-from-soc-serial-number.patch
@@ -6,9 +6,12 @@ Subject: wifi: Set mac address from SoC serial number
 This copies the behavior of the downstream qcacld-3.0 wifi driver.
 Using 00:0a:f5 OUI and lowest 3 bytes from soc serial number.
 
+The WCN3990 firmware on mici reports a bogus 0e:00:00:00:00:00 MAC
+which passes is_valid_ether_addr(), so also override that.
+
 ---
- drivers/net/wireless/ath/ath10k/mac.c | 35 +++++++++++++++++++++++++++
- 1 file changed, 35 insertions(+)
+ drivers/net/wireless/ath/ath10k/mac.c | 46 +++++++++++++++++++++++++++
+ 1 file changed, 46 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath10k/mac.c b/drivers/net/wireless/ath/ath10k/mac.c
 index 154ac7a70..7af4494e1 100644
@@ -23,10 +26,21 @@ index 154ac7a70..7af4494e1 100644
  
  #include "hif.h"
  #include "core.h"
-@@ -233,6 +235,36 @@ int ath10k_mac_ext_resource_config(struct ath10k *ar, u32 val)
+@@ -233,6 +235,47 @@ int ath10k_mac_ext_resource_config(struct ath10k *ar, u32 val)
  	return 0;
  }
  
++/* The WCN3990 firmware reports a bogus locally-administered MAC instead
++ * of leaving the address unset, so it can't be caught by
++ * is_valid_ether_addr() alone.
++ */
++static bool ath10k_mac_is_fw_dummy_addr(const u8 *mac)
++{
++	static const u8 dummy[ETH_ALEN] = { 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00 };
++
++	return ether_addr_equal(mac, dummy);
++}
++
 +static int ath10k_mac_from_socinfo(u8 *mac)
 +{
 +	const struct socinfo *info;
@@ -60,11 +74,12 @@ index 154ac7a70..7af4494e1 100644
  /**********/
  /* Crypto */
  /**********/
-@@ -9998,6 +10030,9 @@ int ath10k_mac_register(struct ath10k *ar)
+@@ -9998,6 +10040,10 @@ int ath10k_mac_register(struct ath10k *ar)
  	void *channels;
  	int ret;
  
-+	if (!is_valid_ether_addr(ar->mac_addr))
++	if (!is_valid_ether_addr(ar->mac_addr) ||
++	    ath10k_mac_is_fw_dummy_addr(ar->mac_addr))
 +		ath10k_mac_from_socinfo(ar->mac_addr);
 +
  	if (!is_valid_ether_addr(ar->mac_addr)) {

--- a/kernel/patches/0016-wifi-ath10k-make-in-order-rx-amsdu-buffers-persisten.patch
+++ b/kernel/patches/0016-wifi-ath10k-make-in-order-rx-amsdu-buffers-persisten.patch
@@ -1,0 +1,136 @@
+From: Richard Acayan <mailingradian@gmail.com>
+Date: Mon, 9 Feb 2026 18:12:58 -0800
+Subject: wifi: ath10k: make in-order rx amsdu buffers persistent
+
+The WCN3990 might split MSDUs among multiple "in-order" indications. The
+driver needs information from previous indications to handle MPDUs that
+are not started by the same indications that complete them. Move the
+list that tracks unprocessed MSDUs to the driver state so the driver can
+handle MPDUs that are split in this way and be less confused.
+
+Fixes: c545070e404b ("ath10k: implement rx reorder support")
+Signed-off-by: Richard Acayan <mailingradian@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt.h    |  4 +++
+ drivers/net/wireless/ath/ath10k/htt_rx.c | 41 ++++++++++++++++++------
+ 2 files changed, 36 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt.h b/drivers/net/wireless/ath/ath10k/htt.h
+index 603f6de62b0a..ec897175c933 100644
+--- a/drivers/net/wireless/ath/ath10k/htt.h
++++ b/drivers/net/wireless/ath/ath10k/htt.h
+@@ -1929,6 +1929,10 @@ struct ath10k_htt {
+ 	bool bundle_tx;
+ 	struct sk_buff_head tx_req_head;
+ 	struct sk_buff_head tx_complete_head;
++
++	u8 rx_in_ord_split_tid;
++	u16 rx_in_ord_split_peer_id;
++	struct sk_buff_head rx_in_ord_split;
+ };
+ 
+ struct ath10k_htt_tx_ops {
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index d7e429041065..b27271c56d07 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -297,6 +297,8 @@ void ath10k_htt_rx_free(struct ath10k_htt *htt)
+ 	skb_queue_purge(&htt->rx_in_ord_compl_q);
+ 	skb_queue_purge(&htt->tx_fetch_ind_q);
+ 
++	skb_queue_purge(&htt->rx_in_ord_split);
++
+ 	spin_lock_bh(&htt->rx_ring.lock);
+ 	ath10k_htt_rx_ring_free(htt);
+ 	spin_unlock_bh(&htt->rx_ring.lock);
+@@ -846,6 +848,8 @@ int ath10k_htt_rx_alloc(struct ath10k_htt *htt)
+ 	skb_queue_head_init(&htt->tx_fetch_ind_q);
+ 	atomic_set(&htt->num_mpdus_ready, 0);
+ 
++	skb_queue_head_init(&htt->rx_in_ord_split);
++
+ 	ath10k_dbg(ar, ATH10K_DBG_BOOT, "htt rx ring size %d fill_level %d\n",
+ 		   htt->rx_ring.size, htt->rx_ring.fill_level);
+ 	return 0;
+@@ -3264,7 +3268,6 @@ static int ath10k_htt_rx_in_ord_ind(struct ath10k *ar, struct sk_buff *skb)
+ 	struct ath10k_htt *htt = &ar->htt;
+ 	struct htt_resp *resp = (void *)skb->data;
+ 	struct ieee80211_rx_status *status = &htt->rx_status;
+-	struct sk_buff_head list;
+ 	struct sk_buff_head amsdu;
+ 	u16 peer_id;
+ 	u16 msdu_count;
+@@ -3299,16 +3302,32 @@ static int ath10k_htt_rx_in_ord_ind(struct ath10k *ar, struct sk_buff *skb)
+ 		return -EINVAL;
+ 	}
+ 
++	if (!skb_queue_empty(&htt->rx_in_ord_split)) {
++		/* It might still be possible to handle this case if there is
++		 * only one peer that splits at each given moment. We are
++		 * bailing out because we should have a test case for this
++		 * before trying to fix it.
++		 */
++		if (tid != htt->rx_in_ord_split_tid
++		 || peer_id != htt->rx_in_ord_split_peer_id
++		 || offload) {
++			ath10k_warn(ar, "split amsdu did not resume immediately\n");
++			htt->rx_confused = true;
++			return -EIO;
++		}
++	}
++
+ 	/* The event can deliver more than 1 A-MSDU. Each A-MSDU is later
+ 	 * extracted and processed.
++	 *
++	 * It can also continue a previous A-MSDU.
+ 	 */
+-	__skb_queue_head_init(&list);
+ 	if (ar->hw_params.target_64bit)
+ 		ret = ath10k_htt_rx_pop_paddr64_list(htt, &resp->rx_in_ord_ind,
+-						     &list);
++						     &htt->rx_in_ord_split);
+ 	else
+ 		ret = ath10k_htt_rx_pop_paddr32_list(htt, &resp->rx_in_ord_ind,
+-						     &list);
++						     &htt->rx_in_ord_split);
+ 
+ 	if (ret < 0) {
+ 		ath10k_warn(ar, "failed to pop paddr list: %d\n", ret);
+@@ -3320,11 +3339,12 @@ static int ath10k_htt_rx_in_ord_ind(struct ath10k *ar, struct sk_buff *skb)
+ 	 * separately.
+ 	 */
+ 	if (offload)
+-		ath10k_htt_rx_h_rx_offload(ar, &list);
++		ath10k_htt_rx_h_rx_offload(ar, &htt->rx_in_ord_split);
+ 
+-	while (!skb_queue_empty(&list)) {
++	while (!skb_queue_empty(&htt->rx_in_ord_split)) {
+ 		__skb_queue_head_init(&amsdu);
+-		ret = ath10k_htt_rx_extract_amsdu(&ar->hw_params, &list, &amsdu);
++		ret = ath10k_htt_rx_extract_amsdu(&ar->hw_params,
++						  &htt->rx_in_ord_split, &amsdu);
+ 		switch (ret) {
+ 		case 0:
+ 			/* Note: The in-order indication may report interleaved
+@@ -3340,12 +3360,15 @@ static int ath10k_htt_rx_in_ord_ind(struct ath10k *ar, struct sk_buff *skb)
+ 			ath10k_htt_rx_h_enqueue(ar, &amsdu, status);
+ 			break;
+ 		case -EAGAIN:
+-			fallthrough;
++			htt->rx_in_ord_split_tid = tid;
++			htt->rx_in_ord_split_peer_id = peer_id;
++
++			return -EIO;
+ 		default:
+ 			/* Should not happen. */
+ 			ath10k_warn(ar, "failed to extract amsdu: %d\n", ret);
+ 			htt->rx_confused = true;
+-			__skb_queue_purge(&list);
++			__skb_queue_purge(&htt->rx_in_ord_split);
+ 			return -EIO;
+ 		}
+ 	}
+-- 
+2.53.0
+
+

--- a/kernel/patches/0017-wifi-ath10k-only-wait-for-response-to-SET_KEY.patch
+++ b/kernel/patches/0017-wifi-ath10k-only-wait-for-response-to-SET_KEY.patch
@@ -1,0 +1,41 @@
+From: Richard Acayan <mailingradian@gmail.com>
+Date: Mon, 9 Feb 2026 18:12:58 -0800
+Subject: wifi: ath10k: only wait for response to SET_KEY
+
+When sending DELETE_KEY, the driver times out waiting for a response
+that doesn't come. Only wait for a response when sending SET_KEY.
+
+Sample dmesg:
+
+	[  117.285854] wlan0: deauthenticating from XX:XX:XX:XX:XX:XX by local choice (Reason: 3=DEAUTH_LEAVING)
+	[  120.302934] ath10k_snoc 18800000.wifi: failed to install key for vdev 0 peer XX:XX:XX:XX:XX:XX: -110
+	[  120.302996] wlan0: failed to remove key (0, XX:XX:XX:XX:XX:XX) from hardware (-110)
+
+Signed-off-by: Richard Acayan <mailingradian@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/mac.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/mac.c b/drivers/net/wireless/ath/ath10k/mac.c
+index da6f7957a0ae..73aa93043f8a 100644
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -324,9 +324,11 @@ static int ath10k_install_key(struct ath10k_vif *arvif,
+ 	if (ret)
+ 		return ret;
+ 
+-	time_left = wait_for_completion_timeout(&ar->install_key_done, 3 * HZ);
+-	if (time_left == 0)
+-		return -ETIMEDOUT;
++	if (cmd != DISABLE_KEY) {
++		time_left = wait_for_completion_timeout(&ar->install_key_done, 3 * HZ);
++		if (time_left == 0)
++			return -ETIMEDOUT;
++	}
+ 
+ 	return 0;
+ }
+-- 
+2.53.0
+
+


### PR DESCRIPTION
## Problem

On the mainline kernel (AGNOS userspace), Wi-Fi collapses under any sustained transfer — a 10 MB scp stalls out and drops the SSH session. Separately, the Wi-Fi MAC address is wrong.

## Root causes

1. **RX instability**: WCN3990 firmware splits A-MSDUs across multiple HTT "in-order" RX indications. Mainline ath10k assumes an A-MSDU never spans indications, so every split poisons the RX path (`failed to extract amsdu: -11`, `rx_confused`), dropping frames and collapsing TCP. Measured 49 kB/s at -36 dBm signal.
2. **MAC**: the firmware reports a bogus `0e:00:00:00:00:00` which *passes* `is_valid_ether_addr()`, so patch 0011's socinfo-derived MAC never applied.

## Changes

- `0016` / `0017`: RFC patches by Richard Acayan from the ath10k list ([1/2](http://lists.infradead.org/pipermail/ath10k/2026-February/016780.html), [2/2](http://lists.infradead.org/pipermail/ath10k/2026-February/016781.html)) — persist the in-order MSDU list in driver state; don't wait for a DELETE_KEY response the firmware never sends (fixes the `-110` key-removal errors also seen in dmesg). Review so far: style nits only; 2/2 independently confirmed on QCA6174. Draft until the series lands upstream in final form.
- `0011`: also treat the `0e:00:00:00:00:00` firmware dummy as invalid so the socinfo MAC (`00:0a:f5` + SoC serial) applies.

## Verification (on mici)

- `permaddr` now `00:0a:f5:6b:1c:e3`
- Throughput 49 kB/s → **16.8 MB/s**, rx rate negotiating 433 Mbps (VHT80 MCS9)
- 20 MB scp both directions, byte-identical, zero amsdu/deauth/key errors in dmesg